### PR TITLE
Take required fields into account in spreadsheet validation

### DIFF
--- a/cidc_schemas/json_validation.py
+++ b/cidc_schemas/json_validation.py
@@ -60,13 +60,20 @@ def _resolve_refs(base_uri: str, json_spec: dict):
     return _do_resolve(json_spec)
 
 
-def validate_instance(instance: str, schema: dict) -> Optional[str]:
+def validate_instance(instance: str, schema: dict, required: bool) -> Optional[str]:
     """
     Validate a data instance against a JSON schema.
 
     Returns None if `instance` is valid, otherwise returns reason for invalidity.
     """
     try:
+        if not instance:
+            if required:
+                raise jsonschema.ValidationError(
+                    'found empty value for required field')
+            else:
+                return None
+
         instance = convert(schema.get('format') or schema['type'], instance)
 
         jsonschema.validate(

--- a/tests/test_template_reader.py
+++ b/tests/test_template_reader.py
@@ -51,14 +51,32 @@ def search_error_message(workbook, template, error, msg_fragment):
 
 def test_missing_headers(tiny_template):
     """Test that a spreadsheet with empty headers raises an assertion error"""
-    tiny_missing = {
+    tiny_missing_header = {
         'TEST_SHEET': [
             (RowType.HEADER, 'test_property', None, 'test_time'),
         ]
     }
 
-    search_error_message(tiny_missing, tiny_template,
+    search_error_message(tiny_missing_header, tiny_template,
                          AssertionError, 'empty header cell')
+
+
+def test_missing_required_value(tiny_template):
+    """Test that spreadsheet with a missing value marked required raises an assertion error"""
+    tiny_missing_value = {
+        'TEST_SHEET': [
+            (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
+            (RowType.DATA, None, '6/11/12', '10:44:61'),
+        ]
+    }
+
+    # tiny_template has no required fields, so this should be valid
+    assert XlTemplateReader(tiny_missing_value).validate(tiny_template)
+
+    # add a required field
+    tiny_template.template_schema['required'] = ['test_property']
+    search_error_message(tiny_missing_value,
+                         tiny_template, ValidationError, 'empty value for required field')
 
 
 def test_wrong_number_of_headers(tiny_template):


### PR DESCRIPTION
When a field isn't required, having an empty value shouldn't throw a validation error. When a field *is* required, having an empty *should* throw a validation error.