### PR TITLE
Don't look for a ref in anything but a dict

### DIFF
--- a/cidc_schemas/json_validation.py
+++ b/cidc_schemas/json_validation.py
@@ -43,7 +43,7 @@ def _resolve_refs(base_uri: str, json_spec: dict):
     resolver = jsonschema.RefResolver(base_uri, json_spec)
 
     def _do_resolve(node):
-        if '$ref' in node:
+        if isinstance(node, collections.Mapping) and '$ref' in node:
             # We found a ref, so return it
             with resolver.resolving(node['$ref']) as resolved:
                 return resolved


### PR DESCRIPTION
Fixes a bug discovered when trying to validate #33. Sometimes `node` will be a value for which the `in` operator isn't supported, in which case we should return it directly.