### PR TITLE
API updates

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -5,3 +5,12 @@
 __author__ = """James Lindsay"""
 __email__ = 'jlindsay@jimmy.harvard.edu'
 __version__ = '0.1.0'
+
+from .template import Template
+
+
+def validate_xlsx(xlsx_path: str, schema_path: str, raise_validation_errors: bool = True):
+    """Check if a populated .xlsx template file is valid w.r.t. the schema at schema_path"""
+    template = Template.from_json(schema_path)
+    validation = template.validate_excel(xlsx_path, raise_validation_errors)
+    return validation

--- a/cidc_schemas/cli.py
+++ b/cidc_schemas/cli.py
@@ -6,7 +6,7 @@ from typing import List
 from . import util
 from .template import Template
 from .json_validation import load_and_validate_schema
-from .constants import SCHEMA_DIR
+from .constants import SCHEMA_DIR, SCHEMA_LIST
 
 
 def main():
@@ -69,8 +69,7 @@ def interface() -> argparse.Namespace:
 
 
 def list_schemas():
-    for path in glob.glob(f'{SCHEMA_DIR}/**/*.json', recursive=True):
-        print(path.replace(SCHEMA_DIR + '/', ''))
+    print('\n'.join(SCHEMA_LIST))
 
 
 def get_schemas_dir(schemas_dir) -> str:

--- a/cidc_schemas/constants.py
+++ b/cidc_schemas/constants.py
@@ -1,3 +1,6 @@
 import os
 
-SCHEMA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas")
+SCHEMA_DIR = os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), "schemas")
+SCHEMA_LIST = [f'{d}/{f}'.replace(f'{SCHEMA_DIR}/', '')
+               for d, _, fs in os.walk(SCHEMA_DIR) for f in fs]

--- a/cidc_schemas/template.py
+++ b/cidc_schemas/template.py
@@ -7,6 +7,7 @@ import json
 from typing import List, Optional, Dict
 from collections import OrderedDict
 
+from .constants import SCHEMA_DIR
 from .json_validation import load_and_validate_schema
 
 logger = logging.getLogger('cidc_schemas.template')
@@ -90,7 +91,7 @@ class Template:
             f'unknown worksheet sections {unknown_props} - only {Template.VALID_WS_SECTIONS} supported'
 
     @staticmethod
-    def from_json(template_schema_path: str, schema_root: str):
+    def from_json(template_schema_path: str, schema_root: str = SCHEMA_DIR):
         """
         Load a Template from a template schema.
 
@@ -109,8 +110,8 @@ class Template:
 
         XlTemplateWriter().write(xlsx_path, self)
 
-    def validate_excel(self, xlsx_path: str) -> bool:
+    def validate_excel(self, xlsx_path: str, raise_validation_errors: bool = True) -> bool:
         """Validate the given Excel file against this `Template`"""
         from .template_reader import XlTemplateReader
 
-        return XlTemplateReader.from_excel(xlsx_path).validate(self)
+        return XlTemplateReader.from_excel(xlsx_path).validate(self, raise_validation_errors)

--- a/tests/test_template_reader.py
+++ b/tests/test_template_reader.py
@@ -43,14 +43,12 @@ def test_valid_from_excel(tiny_template):
 
 def search_error_message(workbook, template, error, msg_fragment):
     reader = XlTemplateReader(workbook)
-    with pytest.raises(error) as e:
+    with pytest.raises(error, match=msg_fragment):
         reader.validate(template)
-
-    assert msg_fragment in str(e.value)
 
 
 def test_missing_headers(tiny_template):
-    """Test that a spreadsheet with empty headers raises an assertion error"""
+    """Test that a spreadsheet with empty headers raises a validation error"""
     tiny_missing_header = {
         'TEST_SHEET': [
             (RowType.HEADER, 'test_property', None, 'test_time'),
@@ -58,11 +56,11 @@ def test_missing_headers(tiny_template):
     }
 
     search_error_message(tiny_missing_header, tiny_template,
-                         AssertionError, 'empty header cell')
+                         ValidationError, 'empty header cell')
 
 
 def test_missing_required_value(tiny_template):
-    """Test that spreadsheet with a missing value marked required raises an assertion error"""
+    """Test that spreadsheet with a missing value marked required raises a validation error"""
     tiny_missing_value = {
         'TEST_SHEET': [
             (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
@@ -80,7 +78,7 @@ def test_missing_required_value(tiny_template):
 
 
 def test_wrong_number_of_headers(tiny_template):
-    """Test that a spreadsheet with multiple or no headers raises an assertion error"""
+    """Test that a spreadsheet with multiple or no headers raises an validation error"""
     tiny_double = {
         'TEST_SHEET': [
             (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
@@ -95,10 +93,10 @@ def test_wrong_number_of_headers(tiny_template):
     }
 
     search_error_message(tiny_double, tiny_template,
-                         AssertionError, 'one header row expected')
+                         ValidationError, 'one header row expected')
 
     search_error_message(tiny_no_headers, tiny_template,
-                         AssertionError, 'one header row expected')
+                         ValidationError, 'one header row expected')
 
 
 def test_missing_schema(tiny_template):


### PR DESCRIPTION
This PR adds a couple non-breaking changes that will be useful for other modules that use the `cidc_schemas` module:
*  Adds `constants.SCHEMA_LIST`, a list of all schemas included by default in the package
*  Adds a top-level `validate_xlsx` convenience function that takes an xlsx path and a schema identifier, without the user having to construct a `Template` or `XlTemplateReader` of their own.
* Adds the `raise_validation_errors` argument to `Template.validate` and `XlTemplateReader.validate`, giving users the option to get back the list of validation errors as a string without a `ValidationError` being raised.

TODO:
* [x] Capture `AssertionErrors` peppered throughout `XlTemplateReader` as validation messages that get raised optionally, otherwise returned