### PR TITLE
Update type hints to reflect openpyxl loader interface

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -6,11 +6,13 @@ __author__ = """James Lindsay"""
 __email__ = 'jlindsay@jimmy.harvard.edu'
 __version__ = '0.1.0'
 
+from typing import Union, BinaryIO
+
 from .template import Template
 
 
-def validate_xlsx(xlsx_path: str, schema_path: str, raise_validation_errors: bool = True):
+def validate_xlsx(xlsx: Union[str, BinaryIO], schema_path: str, raise_validation_errors: bool = True):
     """Check if a populated .xlsx template file is valid w.r.t. the schema at schema_path"""
     template = Template.from_json(schema_path)
-    validation = template.validate_excel(xlsx_path, raise_validation_errors)
+    validation = template.validate_excel(xlsx, raise_validation_errors)
     return validation

--- a/cidc_schemas/template.py
+++ b/cidc_schemas/template.py
@@ -4,7 +4,7 @@
 
 import logging
 import json
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, BinaryIO, Union
 from collections import OrderedDict
 
 from .constants import SCHEMA_DIR
@@ -110,8 +110,8 @@ class Template:
 
         XlTemplateWriter().write(xlsx_path, self)
 
-    def validate_excel(self, xlsx_path: str, raise_validation_errors: bool = True) -> bool:
-        """Validate the given Excel file against this `Template`"""
+    def validate_excel(self, xlsx: Union[str, BinaryIO], raise_validation_errors: bool = True) -> bool:
+        """Validate the given Excel file (either a path or an open file) against this `Template`"""
         from .template_reader import XlTemplateReader
 
-        return XlTemplateReader.from_excel(xlsx_path).validate(self, raise_validation_errors)
+        return XlTemplateReader.from_excel(xlsx).validate(self, raise_validation_errors)

--- a/cidc_schemas/template_reader.py
+++ b/cidc_schemas/template_reader.py
@@ -6,7 +6,7 @@ import os
 import json
 import logging
 from itertools import dropwhile
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, BinaryIO
 
 import openpyxl
 
@@ -48,12 +48,12 @@ class XlTemplateReader:
         self.invalid_messages: List[str] = []
 
     @staticmethod
-    def from_excel(xlsx_path: str):
+    def from_excel(xlsx_path: Union[str, BinaryIO]):
         """
-        Initialize an Excel template reader from an excel path.
+        Initialize an Excel template reader from an excel file.
 
         Arguments:
-          xlsx_path {str} -- path to the Excel template
+          xlsx_path {Union[str, BinaryIO]} -- path to the Excel file or the open file itself.
         """
 
         # Load the Excel file


### PR DESCRIPTION
While working on the validation/ingestion endpoints in cidc-api-gae, it came to my attention that these type hints were misleading -- anywhere we can take a path to an Excel file, we can also take an open file instance.