### PR TITLE
Remove unused or unnecessary requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,8 @@ argparse==1.1
 pyyaml==5.1
 pytest==4.4.1
 jsonschema==3.0.1
-pip==18.1
-bumpversion==0.5.3
-wheel==0.32.1
 flake8==3.5.0
 tox==3.5.2
 coverage==4.5.1
 Sphinx==1.8.1
-strict-rfc3339==0.7
 openpyxl==2.6.2


### PR DESCRIPTION
Including `pip` as a dependency seems to be breaking the https://github.com/cimac-cidc/cidc-api-gae build. This PR removes`pip` from the requirements file, along with some other dependencies that appear to be unused.