### PR TITLE
Update pypi deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ deploy:
   # TODO: should this be on a shared CIDC account?
   username: jlurye-ksg
   password: $PYPI_PASSWORD
+  skip_existing: true
   on:
     branch: master

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,8 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
-include README.rst
+include README.md
+include requirements.txt
 
 graft cidc_schemas/schemas
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.1.0',
+    version='0.1.1',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']


### PR DESCRIPTION
Fixes issue where `requirements.txt` wasn't getting included in the package and prevents Travis from trying to re-deploy to PyPI if the version number hasn't changed.