### PR TITLE
Remove `release` branch info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 | Branch                                                            | Status                                                                                                                             |
 | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | [master](https://cimac-cidc.github.io/cidc-schemas/)              | [![Build Status](https://travis-ci.org/CIMAC-CIDC/cidc-schemas.svg?branch=master)](https://travis-ci.org/CIMAC-CIDC/cidc-schemas)  |
-| [release](https://cimac-cidc.github.io/cidc-schemas/tree/release) | [![Build Status](https://travis-ci.org/CIMAC-CIDC/cidc-schemas.svg?branch=release)](https://travis-ci.org/CIMAC-CIDC/cidc-schemas) |
 
 This repository contains formal definitions of the CIDC metadata model using [json-schema](https://json-schema.org/) syntax and vocabulary.
 


### PR DESCRIPTION
Now that we use PyPI for releases, there's no need for a `release` branch anymore.