### PR TITLE
Add Template.from_type convenience method

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -11,8 +11,8 @@ from typing import Union, BinaryIO
 from .template import Template
 
 
-def validate_xlsx(xlsx: Union[str, BinaryIO], schema_path: str, raise_validation_errors: bool = True):
-    """Check if a populated .xlsx template file is valid w.r.t. the schema at schema_path"""
-    template = Template.from_json(schema_path)
+def validate_xlsx(xlsx: Union[str, BinaryIO], template_type: str, raise_validation_errors: bool = True):
+    """Check if a populated .xlsx template file is valid w.r.t. the template_type"""
+    template = Template.from_type(template_type)
     validation = template.validate_excel(xlsx, raise_validation_errors)
     return validation

--- a/cidc_schemas/template.py
+++ b/cidc_schemas/template.py
@@ -14,6 +14,21 @@ from .json_validation import load_and_validate_schema
 logger = logging.getLogger('cidc_schemas.template')
 
 
+def _get_template_path_map() -> dict:
+    """Build a mapping from template schema types to template schema paths."""
+    path_map = {}
+    for template_type_dir in os.listdir(TEMPLATE_DIR):
+        abs_type_dir = os.path.join(TEMPLATE_DIR, template_type_dir)
+        for template_file in os.listdir(abs_type_dir):
+            template_type = template_file.replace('_template.json', '')
+            template_schema_path = os.path.join(abs_type_dir, template_file)
+            path_map[template_type] = template_schema_path
+    return path_map
+
+
+_TEMPLATE_PATH_MAP = _get_template_path_map()
+
+
 def generate_empty_template(schema_path: str, target_path: str):
     """Write the .xlsx template for the given schema to the target path."""
     logger.info(f"Writing empty template for {schema_path} to {target_path}.")
@@ -119,6 +134,12 @@ class Template:
             Template.VALID_WS_SECTIONS)
         assert not unknown_props, \
             f'unknown worksheet sections {unknown_props} - only {Template.VALID_WS_SECTIONS} supported'
+
+    @staticmethod
+    def from_type(template_type: str):
+        """Load a Template from a template type, e.g., "pbmc" or "wes"."""
+        schema_path = _TEMPLATE_PATH_MAP[template_type]
+        return Template.from_json(schema_path)
 
     @staticmethod
     def from_json(template_schema_path: str, schema_root: str = SCHEMA_DIR):

--- a/cidc_schemas/template.py
+++ b/cidc_schemas/template.py
@@ -138,7 +138,10 @@ class Template:
     @staticmethod
     def from_type(template_type: str):
         """Load a Template from a template type, e.g., "pbmc" or "wes"."""
-        schema_path = _TEMPLATE_PATH_MAP[template_type]
+        try:
+            schema_path = _TEMPLATE_PATH_MAP[template_type]
+        except KeyError:
+            raise Exception(f"unknown template type: {template_type}")
         return Template.from_json(schema_path)
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.1.5',
+    version='0.1.6',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -25,6 +25,9 @@ def test_from_type():
     assert 'PBMCs' in Template.from_type('pbmc').worksheets
     assert 'WES' in Template.from_type('wes').worksheets
 
+    with pytest.raises(Exception, match='unknown template type'):
+        Template.from_type('foo')
+
 
 def test_worksheet_validation():
     """Check validation errors on invalid worksheets"""

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -21,6 +21,11 @@ def test_tiny_loaded(tiny_template):
     assert 'TEST_SHEET' in tiny_template.worksheets
 
 
+def test_from_type():
+    assert 'PBMCs' in Template.from_type('pbmc').worksheets
+    assert 'WES' in Template.from_type('wes').worksheets
+
+
 def test_worksheet_validation():
     """Check validation errors on invalid worksheets"""
 


### PR DESCRIPTION
Make it easier to validate populated manifest / metadata excel templates. Now, instead of supplying the path to the excel template schema, you supply the "template type" (which is something like `wes`, `pbmc`, `cytof`).

This is to make excel template validation easier here: https://github.com/CIMAC-CIDC/cidc-api-gae/blob/5b0cbe32a4d86b28279ba0f686dbe5ffa2481c36/cidc_api/services/ingestion.py#L91