### PR TITLE
v0.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.3.0',
+    version='0.3.1',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']


### PR DESCRIPTION
version bump
with `fix prism.merge_clinical_trial_metadata to not validate patch`