### PR TITLE
merge_artifact requires upload_placeholed uuids to be passed explicitly

### DIFF
--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -653,8 +653,8 @@ def _split_wes_url(obj_url: str) -> WesFileUrlParts:
 
 def merge_artifact(
     ct: dict,
-    artifact_uuid: str,
     assay_type: str,
+    artifact_uuid: str,
     object_url: str,
     file_size_bytes: int,
     uploaded_timestamp: str,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.3.0',
+    version='0.3.1',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.3.1',
+    version='0.4.1',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -412,8 +412,8 @@ def test_merge_artifact_wes_only():
         # attempt to merge
         ct, _ = merge_artifact(
                 ct,
-                artifact_uuid,
                 assay_type="wes",
+                artifact_uuid=artifact_uuid,
                 object_url=url_without_uuid,
                 file_size_bytes=i,
                 uploaded_timestamp="01/01/2001",


### PR DESCRIPTION
fix, but a breaking change - removed uuids as postfix from gs_keys/uris

this needs to be accompanied with:
* CFns / API change that will pass save those uuids in upload job and use them when merging artifact. 
  * [x] https://github.com/CIMAC-CIDC/cidc-api-gae/pull/62/
  * [x] https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/28