### PR TITLE
Add data_format to artifact schema

### DIFF
--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -596,8 +596,7 @@ def _merge_artifact_wes(
         "file_name": wes_object.file_name,
         "file_size_bytes": file_size_bytes,
         "md5_hash": md5_hash,
-        "uploaded_timestamp": uploaded_timestamp,
-        "data_format": "[NOT SET]"
+        "uploaded_timestamp": uploaded_timestamp
     }
 
     
@@ -629,14 +628,7 @@ def _merge_artifact_wes(
     # modify inplace
     record_obj['files'][wes_object.file_name] = artifact
 
-    validator: jsonschema.Draft7Validator = load_and_validate_schema('assays/components/ngs/wes_assay_record.json', return_validator=True)
-    try:
-        validator.validate(record_obj)
-    except jsonschema.exceptions.ValidationError as e:
-        # Since data_format is specified as a constant in the schema,
-        # the validator_value on this exception will be the desired data format.
-        artifact['data_format'] = e.validator_value
-
+    _set_data_format(ct, artifact)
 
     # TODO consider using use merger with template['prism_preamble_object_schema']
     # instead of overwriting it in-place. It will keep 'upload_placeholder' etc.
@@ -658,6 +650,28 @@ def _split_wes_url(obj_url: str) -> WesFileUrlParts:
 
     return WesFileUrlParts(*tokens)
 
+def _set_data_format(ct: dict, artifact: dict):
+    """
+    Discover the correct data format for the given artifact.
+
+    Args:
+        ct: a clinical trial object with artifact inserted
+        artifact: a reference to the artifact object inserted in `ct`.
+
+        NOTE: in-place updates to artifact must trigger in-place updates to `ct`.
+    """
+    # This is invalid for all artifact types, and will
+    # deliberately trigger a validation error below.
+    artifact['data_format'] = '[NOT SET]'
+
+    validator: jsonschema.Draft7Validator = load_and_validate_schema(
+        'clinical_trial.json', return_validator=True)
+    try:
+        validator.validate(ct)
+    except jsonschema.exceptions.ValidationError as e:
+        # Since data_format is specified as a constant in the schema,
+        # the validator_value on this exception will be the desired data format.
+        artifact['data_format'] = e.validator_value
 
 def merge_artifact(
     ct: dict,
@@ -725,6 +739,8 @@ def merge_artifact(
     # artifact_parent[file_name] = Merger(artifact_schema).merge(existing_artifact, artifact)
     # TODO but for now like this
     existing_artifact.update(artifact)
+
+    _set_data_format(ct, existing_artifact)
 
     # return new object and the artifact that was merged
     return ct, artifact

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -624,7 +624,7 @@ def _merge_artifact_wes(
     assert record_obj['cimac_aliquot_id'] == wes_object.cimac_aliquot_id
     assert record_obj['cimac_sample_id'] == wes_object.cimac_sample_id
     assert record_obj['cimac_participant_id'] == wes_object.cimac_participant_id
-    
+
     # modify inplace
     record_obj['files'][wes_object.file_name] = artifact
 

--- a/cidc_schemas/schemas/artifacts/artifact_bam.json
+++ b/cidc_schemas/schemas/artifacts/artifact_bam.json
@@ -12,6 +12,9 @@
       "properties": {
         "info": {
           "type": "object"
+        },
+        "data_format": {
+          "const": "BAM"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_binary.json
+++ b/cidc_schemas/schemas/artifacts/artifact_binary.json
@@ -12,6 +12,9 @@
       "properties": {
         "info": {
           "type": "object"
+        },
+        "data_format": {
+          "const": "BINARY"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_core.json
+++ b/cidc_schemas/schemas/artifacts/artifact_core.json
@@ -55,6 +55,24 @@
         "Pipeline Artifact",
         "Manifest File"
       ]
+    },
+    "data_format": {
+      "description": "Data Format.",
+      "type": "string",
+      "enum": [
+        "FASTA",
+        "FASTQ",
+        "IMAGE",
+        "VCF",
+        "CSV",
+        "XLSX",
+        "NPX",
+        "BAM",
+        "MAF",
+        "BINARY",
+        "TEXT",
+        "[NOT SET]"
+      ]
     }
   },
   "anyOf": [
@@ -65,13 +83,12 @@
         "uploaded_timestamp",
         "file_size_bytes",
         "md5_hash",
-        "artifact_category"
+        "artifact_category",
+        "data_format"
       ]
     },
     {
-      "required": [
-        "upload_placeholder"
-      ]
+      "required": ["upload_placeholder"]
     }
   ]
 }

--- a/cidc_schemas/schemas/artifacts/artifact_csv.json
+++ b/cidc_schemas/schemas/artifacts/artifact_csv.json
@@ -15,6 +15,9 @@
         },
         "header_row": {
           "type": "integer"
+        },
+        "data_format": {
+          "const": "CSV"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_fastq.json
+++ b/cidc_schemas/schemas/artifacts/artifact_fastq.json
@@ -12,6 +12,9 @@
       "properties": {
         "info": {
           "type": "object"
+        },
+        "data_format": {
+          "const": "FASTQ"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_image.json
+++ b/cidc_schemas/schemas/artifacts/artifact_image.json
@@ -18,6 +18,9 @@
         },
         "channels": {
           "type": "integer"
+        },
+        "data_format": {
+          "const": "IMAGE"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_maf.json
+++ b/cidc_schemas/schemas/artifacts/artifact_maf.json
@@ -12,6 +12,9 @@
       "properties": {
         "info": {
           "type": "object"
+        },
+        "data_format": {
+          "const": "MAF"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_npx.json
+++ b/cidc_schemas/schemas/artifacts/artifact_npx.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "xlsx_artifact",
-  "title": "Excel Artifact",
+  "$id": "npx_artifact",
+  "title": "NPX Artifact",
   "type": "object",
   "description": "Information about a xlsx file",
   "allOf": [
@@ -14,15 +14,21 @@
           "type": "integer"
         },
         "aliquots": {
-            "type": "array",
-            "items": {
-                "$comment": "Id of an aliquot within this assay.",
-                "$ref": "aliquot.json#properties/cimac_aliquot_id"
-            }
+          "type": "array",
+          "items": {
+            "$comment": "Id of an aliquot within this assay.",
+            "$ref": "aliquot.json#properties/cimac_aliquot_id"
+          }
+        },
+        "data_format": {
+          "const": "NPX"
         }
       }
     }
   ],
   "mergeStrategy": "objectMerge",
-  "required": ["number_of_aliquots", "aliquots"]
+  "anyOf": [
+    { "required": ["number_of_aliquots", "aliquots"] },
+    { "required": ["upload_placeholder"] }
+  ]
 }

--- a/cidc_schemas/schemas/artifacts/artifact_text.json
+++ b/cidc_schemas/schemas/artifacts/artifact_text.json
@@ -12,6 +12,9 @@
       "properties": {
         "info": {
           "type": "object"
+        },
+        "data_format": {
+          "const": "TEXT"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_vcf.json
+++ b/cidc_schemas/schemas/artifacts/artifact_vcf.json
@@ -12,6 +12,9 @@
       "properties": {
         "info": {
           "type": "object"
+        },
+        "data_format": {
+          "const": "VCF"
         }
       }
     }

--- a/cidc_schemas/schemas/artifacts/artifact_xlsx.json
+++ b/cidc_schemas/schemas/artifacts/artifact_xlsx.json
@@ -12,6 +12,9 @@
       "properties": {
         "info": {
           "type": "object"
+        },
+        "data_format": {
+          "const": "XLSX"
         }
       }
     }

--- a/cidc_schemas/schemas/assays/components/olink/olink_combined.json
+++ b/cidc_schemas/schemas/assays/components/olink/olink_combined.json
@@ -11,7 +11,7 @@
     },
     "study_npx": {
       "$comment": "Normalized Protein eXpression is Olink’s arbitrary unit which is in Log2 scale.",
-      "$ref": "artifacts/artifact_xlsx.json"
+      "$ref": "artifacts/artifact_npx.json"
     }
   },
   "required": [

--- a/cidc_schemas/schemas/assays/components/olink/olink_input.json
+++ b/cidc_schemas/schemas/assays/components/olink/olink_input.json
@@ -6,7 +6,7 @@
   "description": "Olink Assay Input Files",
   "properties": {
     "assay_npx": {
-      "$ref": "artifacts/artifact_xlsx.json",
+      "$ref": "artifacts/artifact_npx.json",
       "$comment": "Normalized Protein eXpression is Olink’s arbitrary unit which is in Log2 scale."
     },
     "assay_raw_ct": {

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.4.3',
+    version='0.4.4',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/data/clinicaltrial_examples/CT_1.json
+++ b/tests/data/clinicaltrial_examples/CT_1.json
@@ -117,7 +117,9 @@
                             "file_size_bytes" :     0,
                             "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
-                            "file_type" :           "NPX"
+                            "data_format" :           "NPX",
+                            "number_of_aliquots":   3,
+                            "aliquots": ["a", "b", "c"]
                         },
                         "assay_raw_ct": {
                             "file_name" :           "...",
@@ -126,7 +128,7 @@
                             "file_size_bytes" :     0,
                             "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
-                            "file_type" :           "Other"
+                            "data_format" :           "XLSX"
                         }
                     }
                 }, 
@@ -143,7 +145,9 @@
                             "file_size_bytes" :     0,
                             "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
-                            "file_type" :           "NPX"
+                            "data_format" :           "NPX",
+                            "number_of_aliquots":   3,
+                            "aliquots": ["a", "b", "c"]
                         },
                         "assay_raw_ct": {
                             "file_name" :           "...",
@@ -152,7 +156,7 @@
                             "file_size_bytes" :     0,
                             "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
-                            "file_type" :           "Other"
+                            "data_format" :           "XLSX"
                         }
                     }
                 }
@@ -180,7 +184,8 @@
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC"
+                                "artifact_category" :   "Assay Artifact from CIMAC",
+                                "data_format":          "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -188,7 +193,8 @@
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC"
+                                "artifact_category" :   "Assay Artifact from CIMAC",
+                                "data_format":          "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -196,7 +202,8 @@
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC"
+                                "artifact_category" :   "Assay Artifact from CIMAC",
+                                "data_format":          "TEXT"
                             }
                         }
                     }, 
@@ -215,7 +222,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -224,7 +231,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -233,7 +240,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "TEXT"
                             }
                         }
                     }
@@ -261,7 +268,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -270,7 +277,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -279,7 +286,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "TEXT"
                             }
                         }
                     }, 
@@ -298,7 +305,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -307,7 +314,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -316,7 +323,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "TEXT"
                             }
                         }
                     }

--- a/tests/data/clinicaltrial_examples/CT_1PA_multiWES.json
+++ b/tests/data/clinicaltrial_examples/CT_1PA_multiWES.json
@@ -94,7 +94,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -103,7 +103,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -112,7 +112,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "TEXT"
                             }
                         }
                     },
@@ -131,7 +131,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -140,7 +140,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "FASTQ"
+                                "data_format" :           "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -149,7 +149,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "TEXT"
                             }
                         }
                     }
@@ -177,7 +177,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -186,7 +186,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -195,7 +195,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "TEXT"
                             }
                         }
                     },
@@ -214,7 +214,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "FASTQ"
                             },
                             "fastq_2":{
                                 "file_name" :           "...",
@@ -223,7 +223,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "FASTQ"
                             },
                             "read_group_mapping_file":{
                                 "file_name" :           "...",
@@ -232,7 +232,7 @@
                                 "file_size_bytes" :     0,
                                 "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
-                                "file_type" :           "Other"
+                                "data_format" :           "TEXT"
                             }
                         }
                     }

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -18,7 +18,7 @@ BASE_OBJ = {
     "object_url": "dummy",
     "file_name": "dummy.txt",
     "file_size_bytes": 1,
-    "file_type": "FASTA",
+    "data_format": "FASTA",
     "md5_hash": "dummy",
     "uploaded_timestamp": "dummy",
     "uploader": "dummy",
@@ -61,6 +61,7 @@ def test_upload_placeholder_oneOf_required():
 
     # create validator assert schemas are valid.
     obj = BASE_OBJ.copy()
+    obj['data_format'] = 'CSV'
     at_validator = _fetch_validator("core")
     at_validator.validate(obj)
 
@@ -74,7 +75,6 @@ def test_upload_placeholder_oneOf_required():
     with pytest.raises(jsonschema.ValidationError):
         at_validator.validate(obj)
 
-
     obj['upload_placeholder'] = "some uuid or job_id"
     at_validator.validate(obj)
 
@@ -87,6 +87,7 @@ def test_text():
 
     # create validator assert schemas are valid.
     obj = BASE_OBJ.copy()
+    obj['data_format'] = 'TEXT'
     at_validator = _fetch_validator("text")
     at_validator.validate(obj)
 
@@ -103,6 +104,7 @@ def test_image():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj['data_format'] = 'IMAGE'
     obj['height'] = 128
     obj['width'] = 128
     obj['channels'] = 8
@@ -116,6 +118,7 @@ def test_binary():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj['data_format'] = 'BINARY'
     obj['info'] = {"test": 128}
     at_validator.validate(obj)
 
@@ -127,6 +130,7 @@ def test_csv():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj['data_format'] = 'CSV'
     obj["header_row"] = 128
     obj["separator"] = ","
     at_validator.validate(obj)
@@ -139,6 +143,7 @@ def test_npx():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj['data_format'] = 'NPX'
 
     # should fail
     with pytest.raises(jsonschema.ValidationError):

--- a/tests/test_assays.py
+++ b/tests/test_assays.py
@@ -15,7 +15,7 @@ ARTIFACT_OBJ = {
     "object_url": "dummy",
     "file_name": "dummy.txt",
     "file_size_bytes": 1,
-    "file_type": "FASTA",
+    "data_format": "FASTA",
     "md5_hash": "dummy",
     "uploaded_timestamp": "dummy",
     "uploader": "dummy",
@@ -80,9 +80,13 @@ def test_wes():
 
     # create the wes object
     fastq_1 = ARTIFACT_OBJ.copy()
+    fastq_1['data_format'] = 'FASTQ'
     rgmf = ARTIFACT_OBJ.copy()
+    rgmf['data_format'] = 'TEXT'
     bam = ARTIFACT_OBJ.copy()
+    bam['data_format']= 'BAM'
     vcf = ARTIFACT_OBJ.copy()
+    vcf['data_format'] = 'VCF'
     rgmf['artifact_category'] = 'Assay Artifact from CIMAC'
     record = {
         "enrichment_vendor_kit": "Twist",
@@ -148,7 +152,9 @@ def test_rna_expression():
 
     # create the wes object
     fastq_1 = ARTIFACT_OBJ.copy()
+    fastq_1['data_format'] = 'FASTQ'
     rgmf = ARTIFACT_OBJ.copy()
+    rgmf['data_format'] = 'TEXT'
     rgmf['artifact_category'] = 'Assay Artifact from CIMAC'
     record = {
         "enrichment_vendor_kit": "Twist",
@@ -211,9 +217,11 @@ def test_cytof():
     obj = {**ASSAY_CORE, **cytof_platform, **
            cytof_panel}    # merge two dictionaries
 
-    # create the wes object
+    # create the cytof object
     fcs_1 = ARTIFACT_OBJ.copy()
+    fcs_1['data_format'] = 'BINARY'
     fcs_2 = ARTIFACT_OBJ.copy()
+    fcs_2['data_format'] = 'BINARY'
     record = {
         "processed_fcs_filename": "dummy",
         "source_fcs_filenames": "dummies",
@@ -248,13 +256,16 @@ def test_mif():
 
     # create the artifact object
     image_1 = ARTIFACT_OBJ.copy()
+    image_1['data_format'] = 'IMAGE'
     image_1["height"] = 300
     image_1["width"] = 250
     image_1["channels"] = 3
     csv_1 = ARTIFACT_OBJ.copy()
+    csv_1['data_format'] = 'CSV'
     csv_1["separator"] = ","
     csv_1["header_row"] = 128
     text = ARTIFACT_OBJ.copy()
+    text['data_format'] = 'TEXT'
     record = {
         "project_inform_folder": "dummy",
         "mif_exported_data_folder": "dummy_value",
@@ -307,10 +318,12 @@ def test_micsss():
 
     # create the artifact object
     image_1 = ARTIFACT_OBJ.copy()
+    image_1['data_format'] = 'IMAGE'
     image_1["height"] = 300
     image_1["width"] = 250
     image_1["channels"] = 3
     csv_1 = ARTIFACT_OBJ.copy()
+    csv_1['data_format'] = 'CSV'
     csv_1["separator"] = ","
     csv_1["header_row"] = 128
     record = {
@@ -358,11 +371,16 @@ def test_olink():
     obj['panel'] = "panel v1"
 
     # create the olink object
-    text = ARTIFACT_OBJ.copy()
+    npx = ARTIFACT_OBJ.copy()
+    npx['data_format'] = 'NPX'
+    npx['aliquots'] = ['a', 'b', 'c']
+    npx['number_of_aliquots'] = 3
+    xlsx = ARTIFACT_OBJ.copy()
+    xlsx['data_format'] = 'XLSX'
     record = OLINK_RECORD.copy()
-    record["files"]["assay_npx"] = text
-    record["files"]["assay_raw_ct"] = text
-    record["files"]["study_npx"] = text
+    record["files"]["assay_npx"] = npx
+    record["files"]["assay_raw_ct"] = xlsx
+    record["files"]["study_npx"] = npx
 
     # add a demo record.
     obj['records'] = [

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -607,6 +607,9 @@ def test_end_to_end_wes_olink(schema_path, xlsx_path):
     # `merge_artifact` modifies ct in-place, so 
     full_ct = merge_clinical_trial_metadata(patch_copy_4_artifacts, original_ct)
 
+    # validate the full clinical trial object
+    validator.validate(full_ct)
+
     if hint == 'wes':
         assert len(merged_gs_keys) == 3*2 # 3 files per entry in xlsx
 
@@ -648,8 +651,8 @@ def test_end_to_end_wes_olink(schema_path, xlsx_path):
     elif hint == "olink":
         assert list(dd.keys()) == ['dictionary_item_added'], "Unexpected CT changes"
 
-        # 6 artifact atributes * 5 files (2 per record + 1 study)
-        assert len(dd['dictionary_item_added']) == 6*(2*2+1), "Unexpected CT changes"
+        # 7 artifact atributes * 5 files (2 per record + 1 study)
+        assert len(dd['dictionary_item_added']) == 7*(2*2+1), "Unexpected CT changes"
 
     else:
         assert False, f"add {hint} assay specific asserts"

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -469,8 +469,8 @@ def test_merge_artifact_wes_only():
 
     dd = DeepDiff(WES_TEMPLATE_EXAMPLE_CT,ct)
 
-    # we add 6 required fields per artifact thus `*6`
-    assert len(dd['dictionary_item_added']) == len(WES_TEMPLATE_EXAMPLE_GS_URLS)*6, "Unexpected CT changes"
+    # we add 7 required fields per artifact thus `*7`
+    assert len(dd['dictionary_item_added']) == len(WES_TEMPLATE_EXAMPLE_GS_URLS)*7, "Unexpected CT changes"
 
     # in the process upload_placeholder gets removed per artifact
     assert len(dd['dictionary_item_removed']) == len(WES_TEMPLATE_EXAMPLE_GS_URLS), "Unexpected CT changes"
@@ -556,8 +556,7 @@ def test_end_to_end_wes_olink(schema_path, xlsx_path):
     validator = load_and_validate_schema("clinical_trial.json", return_validator=True)
     
     # parse the spreadsheet and get the file maps
-    prism_patch, file_maps = prismify(xlsx_path, schema_path, assay_hint=hint)
-
+    prism_patch, file_maps = prismify(xlsx_path, schema_path, assay_hint=hint, verb=True)
 
     # olink is different in structure - no array of assays, only one.
     if hint != 'olink':
@@ -637,8 +636,8 @@ def test_end_to_end_wes_olink(schema_path, xlsx_path):
     dd = DeepDiff(full_after_prism, full_ct)
 
     if hint=='wes':
-        # 6 files * 6 artifact atributes
-        assert len(dd['dictionary_item_added']) == 6*6, "Unexpected CT changes"
+        # 6 files * 7 artifact atributes
+        assert len(dd['dictionary_item_added']) == 6*7, "Unexpected CT changes"
 
         # in the process upload_placeholder gets removed per artifact = 6
         assert len(dd['dictionary_item_removed']) == len(merged_gs_keys), "Unexpected CT changes"


### PR DESCRIPTION
Every artifact now must contain info about its data format (e.g., `FASTQ`, `NPX`), primarily for use in the portal UI file browser. The appropriate data format for an artifact type is encoded as a constant in that artifact type's schema. The `_set_data_format` function uses these schemas to infer the appropriate data format for an artifact when `merge_artifact` is called. 

Otherwise, this PR mostly just updates test data to conform to the new artifact schemas.