### PR TITLE
Fix merge artifact

### DIFF
--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -743,7 +743,7 @@ def merge_artifact(
     _set_data_format(ct, existing_artifact)
 
     # return new object and the artifact that was merged
-    return ct, artifact
+    return ct, existing_artifact
 
 class InvalidMergeTargetException(ValueError):
     """Exception raised for target of merge_clinical_trial_metadata being non schema compliant."""

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.4.4',
+    version='0.4.5',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -445,7 +445,7 @@ def test_merge_artifact_wes_only():
         url_without_uuid = url[:-1*(1+len(artifact_uuid))]
 
         # attempt to merge
-        ct, _ = merge_artifact(
+        ct, artifact = merge_artifact(
                 ct,
                 assay_type="wes",
                 artifact_uuid=artifact_uuid,
@@ -457,6 +457,9 @@ def test_merge_artifact_wes_only():
 
         # assert we still have a good clinical trial object.
         validator.validate(ct)
+
+        # check that the data_format was set
+        assert 'data_format' in artifact
 
         # search for this url and all previous (no clobber)
         searched_urls.append(url_without_uuid)
@@ -476,6 +479,7 @@ def test_merge_artifact_wes_only():
     assert len(dd['dictionary_item_removed']) == len(WES_TEMPLATE_EXAMPLE_GS_URLS), "Unexpected CT changes"
     assert list(dd.keys()) == ['dictionary_item_added', 'dictionary_item_removed'], "Unexpected CT changes"
 
+    validator.validate(ct)
 
 def test_merge_ct_meta():
     """ 
@@ -587,7 +591,7 @@ def test_end_to_end_wes_olink(schema_path, xlsx_path):
     for i, fmap_entry in enumerate(file_maps):
 
         # attempt to merge
-        patch_copy_4_artifacts, _ = merge_artifact(
+        patch_copy_4_artifacts, artifact = merge_artifact(
                 patch_copy_4_artifacts,
                 artifact_uuid=fmap_entry.upload_placeholder,
                 object_url=fmap_entry.gs_key,
@@ -599,6 +603,9 @@ def test_end_to_end_wes_olink(schema_path, xlsx_path):
 
         # assert we still have a good clinical trial object, so we can save it
         validator.validate(merge_clinical_trial_metadata(patch_copy_4_artifacts, original_ct))
+
+        # check that the data_format was set
+        assert 'data_format' in artifact
 
         # we will than search for this url in the resulting ct, 
         # to check all artifacts were indeed merged

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -479,8 +479,6 @@ def test_merge_artifact_wes_only():
     assert len(dd['dictionary_item_removed']) == len(WES_TEMPLATE_EXAMPLE_GS_URLS), "Unexpected CT changes"
     assert list(dd.keys()) == ['dictionary_item_added', 'dictionary_item_removed'], "Unexpected CT changes"
 
-    validator.validate(ct)
-
 def test_merge_ct_meta():
     """ 
     tests merging of two clinical trial metadata


### PR DESCRIPTION
The artifact object without `data_format` was getting returned for non-WES assays, leading to downstream errors while trying to create `DownloadableFiles` in the `ingest_upload` cloud function 😓