### PR TITLE
Excel file validation updates

### DIFF
--- a/cidc_schemas/json_validation.py
+++ b/cidc_schemas/json_validation.py
@@ -107,7 +107,7 @@ def _resolve_refs(base_uri: str, json_spec: dict) -> dict:
     """
     resolver = jsonschema.RefResolver(base_uri, json_spec)
 
-    def _resolve_ref(ref:str) -> dict:
+    def _resolve_ref(ref: str) -> dict:
         with resolver.resolving(ref) as resolved_spec:
             # resolved_spec might have unresolved refs in it, so we pass
             # it back to _resolve_refs to resolve them. This way,
@@ -117,32 +117,30 @@ def _resolve_refs(base_uri: str, json_spec: dict) -> dict:
     return _map_refs(json_spec, _resolve_ref)
 
 
-def validate_instance(instance: str, schema: dict, required: bool) -> Optional[str]:
+def validate_instance(instance: str, schema: dict) -> Optional[str]:
     """
     Validate a data instance against a JSON schema.
 
     Returns None if `instance` is valid, otherwise returns reason for invalidity.
     """
     try:
-        if not instance:
-            if required:
-                raise jsonschema.ValidationError(
-                    'found empty value for required field')
-            else:
-                return None
+        if instance is None:
+            raise jsonschema.ValidationError(
+                'found empty value for required field')
 
         stype = schema.get('format')
         if not stype:
             stype = schema.get('type')
         if not stype:
             if 'allOf' in schema:
-                types = set(s.get('type') for s in schema['allOf'] if 'type' in s)
+                types = set(s.get('type')
+                            for s in schema['allOf'] if 'type' in s)
                 # if all types in 'allOf' are the same:
                 if len(types) == 1:
                     stype = types.pop()
                 else:
                     return f"Value can't be of multiple different types ({types}), "\
-                    "as 'allOf' in schema specifies."
+                        "as 'allOf' in schema specifies."
 
         instance = convert(stype, instance)
 
@@ -171,6 +169,7 @@ def _to_time(value):
     if not dt:
         raise ValueError(f"could not convert \"{value}\" to time")
     return dt.strftime('%H:%M:%S')
+
 
 def _to_datetime(value):
     dt = _get_datetime(value)

--- a/cidc_schemas/json_validation.py
+++ b/cidc_schemas/json_validation.py
@@ -117,7 +117,7 @@ def _resolve_refs(base_uri: str, json_spec: dict) -> dict:
     return _map_refs(json_spec, _resolve_ref)
 
 
-def validate_instance(instance: str, schema: dict) -> Optional[str]:
+def validate_instance(instance: str, schema: dict, is_required=False) -> Optional[str]:
     """
     Validate a data instance against a JSON schema.
 
@@ -125,8 +125,11 @@ def validate_instance(instance: str, schema: dict) -> Optional[str]:
     """
     try:
         if instance is None:
-            raise jsonschema.ValidationError(
-                'found empty value for required field')
+            if is_required:
+                raise jsonschema.ValidationError(
+                    'found empty value for required field')
+            else:
+                return None
 
         stype = schema.get('format')
         if not stype:

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -453,7 +453,7 @@ def prismify(xlsx_path: Union[str, BinaryIO], template_path: str, assay_hint: st
 
         # Here we take only first two cells from preamble as key and value respectfully,
         # lowering keys to match template schema definitions.
-        preamble_context = dict((r[0].lower(), r[1]) for r in ws.get(RowType.PREAMBLE, []))
+        preamble_context = dict((r.values[0].lower(), r.values[1]) for r in ws.get(RowType.PREAMBLE, []))
         # We need this full "preamble dict" (all key-value pairs) prior to processing
         # properties from data_columns or preamble wrt template schema definitions, because 
         # there can be a 'gcs_uri_format' that needs to have access to all values.
@@ -486,10 +486,10 @@ def prismify(xlsx_path: Union[str, BinaryIO], template_path: str, assay_hint: st
                 # We create this "data record dict" (all key-value pairs) prior to processing
                 # properties from data_columns wrt template schema definitions, because 
                 # there can be a 'gcs_uri_format' that needs to have access to all values.
-                local_context = dict(zip([h.lower() for h in headers], row))
+                local_context = dict(zip([h.lower() for h in headers.values], row.values))
 
                 # create dictionary per row
-                for key, val in zip(headers, row):
+                for key, val in zip(headers.values, row.values):
                     
                     # get corr xsls schema type 
                     new_file = _process_property(
@@ -518,7 +518,7 @@ def prismify(xlsx_path: Union[str, BinaryIO], template_path: str, assay_hint: st
         for row in ws[RowType.PREAMBLE]:
             # process this property
             new_file = _process_property(
-                row[0], row[1], 
+                row.values[0], row.values[1], 
                 assay_hint=assay_hint, 
                 key_lu=xlsx_template.key_lu, 
                 data_obj=preamble_obj, 

--- a/cidc_schemas/template_reader.py
+++ b/cidc_schemas/template_reader.py
@@ -171,6 +171,9 @@ class XlTemplateReader:
 
         return True
 
+    def _make_validation_error(self, worksheet_name: str, field_name: str, message: str) -> str:
+        return f'Error in worksheet "{worksheet_name}", field "{field_name}"": {message}'
+
     def _validate_worksheet(self, worksheet_name: str, ws_schema: dict, required: List[str]) -> List[str]:
         """Validate rows in a worksheet, returning a list of validation error messages."""
 
@@ -192,8 +195,9 @@ class XlTemplateReader:
                 invalid_reason = validate_instance(value, schema, is_required)
 
                 if invalid_reason:
-                    invalid_messages.append(
-                        f'{worksheet_name}: Header, {key}:\t{invalid_reason}')
+                    message = self._make_validation_error(
+                        worksheet_name, key, invalid_reason)
+                    invalid_messages.append(message)
 
         if 'data_columns' in ws_schema:
             # Build up flat mapping of data schemas
@@ -225,7 +229,8 @@ class XlTemplateReader:
                         value, data_schemas[col], is_required)
 
                     if invalid_reason:
-                        invalid_messages.append(
-                            f'{worksheet_name}: Data, {headers[col]}:\t{invalid_reason}')
+                        message = self._make_validation_error(
+                            worksheet_name, headers[col], invalid_reason)
+                        invalid_messages.append(message)
 
         return invalid_messages

--- a/cidc_schemas/template_reader.py
+++ b/cidc_schemas/template_reader.py
@@ -68,7 +68,7 @@ class XlTemplateReader:
             worksheet = workbook[worksheet_name]
             rows = []
             header_width = 0
-            for i, row in enumerate(worksheet.iter_rows()):
+            for row_num, row in enumerate(worksheet.iter_rows(), start=1):
                 # Convert to string and extract type annotation
                 typ, *values = [col.value for col in row]
                 row_type = row_type_from_string(typ)
@@ -76,7 +76,7 @@ class XlTemplateReader:
                 # If no recognized row type found, don't parse this row
                 if not row_type:
                     logger.info(
-                        f'No recognized row type found in row {i + 1} - skipping')
+                        f'No recognized row type found in row {row_num} - skipping')
                     continue
 
                 # If entire row is empty, skip it (this happens at the bottom of the data table, e.g.)
@@ -96,7 +96,7 @@ class XlTemplateReader:
                     values = values[:header_width]
 
                 # Reassemble parsed row and add to rows
-                new_row = TemplateRow(i + 1, row_type, values)
+                new_row = TemplateRow(row_num, row_type, values)
                 rows.append(new_row)
             template[worksheet_name] = rows
 

--- a/cidc_schemas/template_reader.py
+++ b/cidc_schemas/template_reader.py
@@ -173,6 +173,10 @@ class XlTemplateReader:
         row_note = f", row {row_num}" if row_num is not None else ""
         return f'Error in worksheet "{worksheet_name}", field "{field_name}"{row_note}: {message}'
 
+    def _validate_instance(self, value, schema):
+        # All fields in an Excel template are required
+        return validate_instance(value, schema, is_required=True)
+
     def _validate_worksheet(self, worksheet_name: str, ws_schema: dict) -> List[str]:
         """Validate rows in a worksheet, returning a list of validation error messages."""
 
@@ -190,7 +194,7 @@ class XlTemplateReader:
             for key, *values in row_groups[RowType.PREAMBLE]:
                 value = values[0]
                 schema = self._get_schema(key, preamble_schemas)
-                invalid_reason = validate_instance(value, schema)
+                invalid_reason = self._validate_instance(value, schema)
 
                 if invalid_reason:
                     message = self._make_validation_error(
@@ -222,7 +226,7 @@ class XlTemplateReader:
 
             for row, data_row in enumerate(row_groups[RowType.DATA]):
                 for col, value in enumerate(data_row):
-                    invalid_reason = validate_instance(
+                    invalid_reason = self._validate_instance(
                         value, data_schemas[col])
 
                     if invalid_reason:

--- a/cidc_schemas/template_writer.py
+++ b/cidc_schemas/template_writer.py
@@ -23,12 +23,12 @@ class RowType(Enum):
     PREAMBLE = "#p"
     DATA = "#d"
 
-    @staticmethod
-    def from_string(maybe_type: str) -> Optional[Enum]:
-        try:
-            return RowType(maybe_type)
-        except ValueError:
-            return None
+
+def row_type_from_string(maybe_type: str) -> Optional[RowType]:
+    try:
+        return RowType(maybe_type)
+    except ValueError:
+        return None
 
 
 class XlThemes:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.4.8',
+    version='0.4.9',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/test_template_reader.py
+++ b/tests/test_template_reader.py
@@ -68,7 +68,7 @@ def test_missing_required_value(tiny_template):
         ]
     }
 
-    message = 'Error in worksheet "TEST_SHEET", field "test_property": found empty value'
+    message = 'Error in worksheet "TEST_SHEET", field "test_property", row 0: found empty value'
     search_error_message(tiny_missing_value,
                          tiny_template, ValidationError, message)
 

--- a/tests/test_template_reader.py
+++ b/tests/test_template_reader.py
@@ -73,8 +73,9 @@ def test_missing_required_value(tiny_template):
 
     # add a required field
     tiny_template.schema['required'] = ['test_property']
+    message = 'Error in worksheet "TEST_SHEET", field "test_property"": found empty value'
     search_error_message(tiny_missing_value,
-                         tiny_template, ValidationError, 'empty value for required field')
+                         tiny_template, ValidationError, message)
 
 
 def test_wrong_number_of_headers(tiny_template):

--- a/tests/test_template_reader.py
+++ b/tests/test_template_reader.py
@@ -68,12 +68,7 @@ def test_missing_required_value(tiny_template):
         ]
     }
 
-    # tiny_template has no required fields, so this should be valid
-    assert XlTemplateReader(tiny_missing_value).validate(tiny_template)
-
-    # add a required field
-    tiny_template.schema['required'] = ['test_property']
-    message = 'Error in worksheet "TEST_SHEET", field "test_property"": found empty value'
+    message = 'Error in worksheet "TEST_SHEET", field "test_property": found empty value'
     search_error_message(tiny_missing_value,
                          tiny_template, ValidationError, message)
 

--- a/tests/test_template_reader.py
+++ b/tests/test_template_reader.py
@@ -9,7 +9,7 @@ import jsonschema
 from typing import List
 from openpyxl import load_workbook
 
-from cidc_schemas.template_reader import XlTemplateReader, ValidationError
+from cidc_schemas.template_reader import XlTemplateReader, ValidationError, TemplateRow
 from cidc_schemas.template_writer import RowType
 
 from .constants import TEMPLATE_EXAMPLES_DIR, TEST_DATA_DIR
@@ -21,12 +21,13 @@ def test_valid(tiny_template):
     """Test that a known-valid spreadsheet is considered valid"""
     tiny_valid = {
         'TEST_SHEET': [
-            (RowType.PREAMBLE, 'test_property', 'foo'),
-            (RowType.PREAMBLE, 'test_date', '6/11/12'),
-            (RowType.PREAMBLE, 'test_time', '10:44:61'),
-            (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
-            (RowType.DATA, 'foo', '6/11/12', '10:44:61'),
-            (RowType.DATA, 'foo', '6/12/12', '10:45:61')
+            TemplateRow(1, RowType.PREAMBLE, ('test_property', 'foo')),
+            TemplateRow(2, RowType.PREAMBLE, ('test_date', '6/11/12')),
+            TemplateRow(3, RowType.PREAMBLE, ('test_time', '10:44:61')),
+            TemplateRow(4, RowType.HEADER, ('test_property',
+                                            'test_date', 'test_time')),
+            TemplateRow(5, RowType.DATA, ('foo', '6/11/12', '10:44:61')),
+            TemplateRow(6, RowType.DATA, ('foo', '6/12/12', '10:45:61'))
         ]
     }
 
@@ -51,7 +52,8 @@ def test_missing_headers(tiny_template):
     """Test that a spreadsheet with empty headers raises a validation error"""
     tiny_missing_header = {
         'TEST_SHEET': [
-            (RowType.HEADER, 'test_property', None, 'test_time'),
+            TemplateRow(1, RowType.HEADER,
+                        ('test_property', None, 'test_time')),
         ]
     }
 
@@ -63,12 +65,13 @@ def test_missing_required_value(tiny_template):
     """Test that spreadsheet with a missing value marked required raises a validation error"""
     tiny_missing_value = {
         'TEST_SHEET': [
-            (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
-            (RowType.DATA, None, '6/11/12', '10:44:61'),
+            TemplateRow(1, RowType.HEADER, ('test_property',
+                                            'test_date', 'test_time')),
+            TemplateRow(2, RowType.DATA, (None, '6/11/12', '10:44:61')),
         ]
     }
 
-    message = 'Error in worksheet "TEST_SHEET", field "test_property", row 0: found empty value'
+    message = 'Error in worksheet "TEST_SHEET", field "test_property", row 2: found empty value'
     search_error_message(tiny_missing_value,
                          tiny_template, ValidationError, message)
 
@@ -77,14 +80,16 @@ def test_wrong_number_of_headers(tiny_template):
     """Test that a spreadsheet with multiple or no headers raises an validation error"""
     tiny_double = {
         'TEST_SHEET': [
-            (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
-            (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
+            TemplateRow(1, RowType.HEADER, ('test_property',
+                                            'test_date', 'test_time')),
+            TemplateRow(2, RowType.HEADER, ('test_property',
+                                            'test_date', 'test_time')),
         ]
     }
 
     tiny_no_headers = {
         'TEST_SHEET': [
-            (RowType.DATA, 1, 2, 3)
+            TemplateRow(1, RowType.DATA, (1, 2, 3))
         ]
     }
 
@@ -99,7 +104,7 @@ def test_missing_schema(tiny_template):
     """Test that a spreadsheet with an unknown property raises an assertion error"""
     tiny_missing = {
         'TEST_SHEET': [
-            (RowType.PREAMBLE, 'missing_property', 'foo'),
+            TemplateRow(1, RowType.PREAMBLE, ('missing_property', 'foo')),
         ]
     }
 
@@ -111,12 +116,13 @@ def test_invalid(tiny_template):
     """Test that a known-invalid spreadsheet is considered invalid"""
     tiny_invalid = {
         'TEST_SHEET': [
-            (RowType.PREAMBLE, 'test_property', 'foo'),
-            (RowType.PREAMBLE, 'test_date', '6foo'),
-            (RowType.PREAMBLE, 'test_time', '10:foo:61'),
-            (RowType.HEADER, 'test_property', 'test_date', 'test_time'),
-            (RowType.DATA, 'foo', '6/11/foo', '10::::44:61'),
-            (RowType.DATA, 'foo', '6//12', '10:45:61asdf')
+            TemplateRow(2, RowType.PREAMBLE, ('test_property', 'foo')),
+            TemplateRow(2, RowType.PREAMBLE, ('test_date', '6foo')),
+            TemplateRow(2, RowType.PREAMBLE, ('test_time', '10:foo:61')),
+            TemplateRow(2, RowType.HEADER, ('test_property',
+                                            'test_date', 'test_time')),
+            TemplateRow(2, RowType.DATA, ('foo', '6/11/foo', '10::::44:61')),
+            TemplateRow(2, RowType.DATA, ('foo', '6//12', '10:45:61asdf'))
         ]
     }
 

--- a/tests/test_template_writer.py
+++ b/tests/test_template_writer.py
@@ -2,7 +2,7 @@
 
 """Tests for `cidc_schemas.template_writer` module."""
 
-from cidc_schemas.template_writer import XlTemplateWriter, RowType
+from cidc_schemas.template_writer import XlTemplateWriter, RowType, row_type_from_string
 
 
 def test_get_validation():
@@ -23,6 +23,6 @@ def test_get_validation():
 def test_row_type_from_string():
     """Test RowType extraction from parsed strings"""
 
-    assert RowType.from_string("#t") == RowType.TITLE
-    assert RowType.from_string("t") == None
-    assert RowType.from_string("") == None
+    assert row_type_from_string("#t") == RowType.TITLE
+    assert row_type_from_string("t") == None
+    assert row_type_from_string("") == None

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -86,7 +86,7 @@ def compare_templates(schema_path: str, generated: XlTemplateReader, reference: 
 
         assert len(gen_ws[RowType.HEADER]) == len(ref_ws[RowType.HEADER])
         for gen_headers, ref_headers in zip(gen_ws[RowType.HEADER], ref_ws[RowType.HEADER]):
-        # Compare data headers
+            # Compare data headers
             for (gen_h, ref_h) in zip(gen_headers, ref_headers):
                 assert gen_h == ref_h, error(
                     f'data: generated template had header {gen_h} where reference had {ref_h}')

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -80,13 +80,13 @@ def compare_templates(schema_path: str, generated: XlTemplateReader, reference: 
 
         # Compare preamble rows
         for (gen_row, ref_row) in zip(gen_ws[RowType.PREAMBLE], ref_ws[RowType.PREAMBLE]):
-            gen_key, ref_key = gen_row[0], ref_row[0]
+            gen_key, ref_key = gen_row.values[0], ref_row.values[0]
             assert gen_key == ref_key, error(
                 f'preamble: generated template had key {gen_key} where reference had {ref_key}')
 
         assert len(gen_ws[RowType.HEADER]) == len(ref_ws[RowType.HEADER])
         for gen_headers, ref_headers in zip(gen_ws[RowType.HEADER], ref_ws[RowType.HEADER]):
             # Compare data headers
-            for (gen_h, ref_h) in zip(gen_headers, ref_headers):
+            for (gen_h, ref_h) in zip(gen_headers.values, ref_headers.values):
                 assert gen_h == ref_h, error(
                     f'data: generated template had header {gen_h} where reference had {ref_h}')


### PR DESCRIPTION
* Friendlier error messages, e.g.: 
```
Error in worksheet "PBMC", field "PBMC ALIQUOTED", row 3: <some error message>
```    
* Fixes `XlTemplateReader.validate` to consider any missing field a validation error.