### PR TITLE
moved in_doc_ref_pattern contraint to the cimac_aliqout_id itself

### DIFF
--- a/cidc_schemas/json_validation.py
+++ b/cidc_schemas/json_validation.py
@@ -328,7 +328,10 @@ def validate_instance(instance: str, schema: dict, is_required=False) -> Optiona
         instance = convert(stype, instance)
 
         jsonschema.validate(
-            instance, schema, cls=_Validator, format_checker=jsonschema.FormatChecker()
+            # we're using this to validate only 'basic' values that come from Template cells 
+            # that's why we don't want to check for ref integrity with _Validator here
+            # so a Validator specified in this schema will be used, or a default one
+            instance, schema, format_checker=jsonschema.FormatChecker()
         )
         return None
     except jsonschema.ValidationError as error:

--- a/cidc_schemas/schemas/aliquot.json
+++ b/cidc_schemas/schemas/aliquot.json
@@ -7,6 +7,7 @@
   "properties": {
     "cimac_aliquot_id": {
       "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+      "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
       "type": "string"
     },
     "quantity": {

--- a/cidc_schemas/schemas/aliquot.json
+++ b/cidc_schemas/schemas/aliquot.json
@@ -8,6 +8,7 @@
     "cimac_aliquot_id": {
       "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
       "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
+      "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.",
       "type": "string"
     },
     "quantity": {

--- a/cidc_schemas/schemas/artifacts/artifact_npx.json
+++ b/cidc_schemas/schemas/artifacts/artifact_npx.json
@@ -11,17 +11,15 @@
     {
       "properties": {
         "number_of_aliquots": {
-          "description": "Number of aliquots within this assay.",
+          "description": "Number of aliquots within this file.",
           "type": "integer"
         },
         "aliquots": {
-          "description": "Ids of the aliquot(s) within this assay.",
+          "description": "Ids of the aliquot(s) within this file.",
           "type": "array",
           "items": {
-            "type:": {
-              "$ref": "aliquot.json#properties/cimac_aliquot_id/type"
-            }, 
-            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id"
+            "$comment": "Ids of the aliquot(s) within this file.",
+            "$ref": "aliquot.json#properties/cimac_aliquot_id"
           }
         },
         "data_format": {

--- a/cidc_schemas/schemas/assays/components/cytof/cytof_entry.json
+++ b/cidc_schemas/schemas/assays/components/cytof/cytof_entry.json
@@ -14,11 +14,8 @@
             "$ref": "sample.json#properties/cimac_sample_id"
         },
         "cimac_aliquot_id": {
-            "type:": {
-              "$ref": "aliquot.json#properties/cimac_aliquot_id/type"
-            }, 
-            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
-            "description": "Id of an aliquot within this clinical trial, that this assay record is based upon." 
+            "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+            "$ref": "aliquot.json#properties/cimac_aliquot_id"
         },
         "panel_name": {
             "description": "Standardized CyTOF panel name used for antibody sample development.",

--- a/cidc_schemas/schemas/assays/components/ngs/ngs_assay_record.json
+++ b/cidc_schemas/schemas/assays/components/ngs/ngs_assay_record.json
@@ -14,11 +14,8 @@
         "$ref": "sample.json#properties/cimac_sample_id"
     },
     "cimac_aliquot_id": {
-        "type:": {
-          "$ref": "aliquot.json#properties/cimac_aliquot_id/type"
-        }, 
-        "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
-        "description": "Id of an aliquot within this clinical trial, that this assay record is based upon."
+        "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+        "$ref": "aliquot.json#properties/cimac_aliquot_id"
     },
     "files": {
       "$comment": "Fastq and read group mapping files produced by the assay for that .",

--- a/docs/docs/aliquot.html
+++ b/docs/docs/aliquot.html
@@ -841,7 +841,9 @@
             "type": "string"
         },
         "cimac_aliquot_id": {
+            "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.",
             "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
             "type": "string"
         },
         "extracted_concentration": {

--- a/docs/docs/artifacts.artifact_npx.html
+++ b/docs/docs/artifacts.artifact_npx.html
@@ -106,7 +106,7 @@
     </td>
     <td width=55%>
         
-            Number of aliquots within this assay.
+            Number of aliquots within this file.
         
     </td>
     <td>
@@ -139,7 +139,7 @@
     </td>
     <td width=55%>
         
-            
+            Ids of the aliquot(s) within this file.
         
     </td>
     <td>
@@ -304,9 +304,11 @@
         {
             "properties": {
                 "aliquots": {
+                    "description": "Ids of the aliquot(s) within this file.",
                     "items": {
-                        "$comment": "Ids of the aliquot(s) within this assay.",
+                        "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                         "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                        "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                         "type": "string"
                     },
                     "type": "array"
@@ -316,7 +318,7 @@
                     "description": "Data format."
                 },
                 "number_of_aliquots": {
-                    "description": "Number of aliquots within this assay.",
+                    "description": "Number of aliquots within this file.",
                     "type": "integer"
                 }
             }

--- a/docs/docs/assays.components.available_assays.html
+++ b/docs/docs/assays.components.available_assays.html
@@ -791,8 +791,9 @@
                                     "type": "string"
                                 },
                                 "cimac_aliquot_id": {
-                                    "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                     "type": "string"
                                 },
                                 "cimac_participant_id": {
@@ -4606,9 +4607,11 @@
                                             {
                                                 "properties": {
                                                     "aliquots": {
+                                                        "description": "Ids of the aliquot(s) within this file.",
                                                         "items": {
-                                                            "$comment": "Ids of the aliquot(s) within this assay.",
+                                                            "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                                             "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                             "type": "string"
                                                         },
                                                         "type": "array"
@@ -4618,7 +4621,7 @@
                                                         "description": "Data format."
                                                     },
                                                     "number_of_aliquots": {
-                                                        "description": "Number of aliquots within this assay.",
+                                                        "description": "Number of aliquots within this file.",
                                                         "type": "integer"
                                                     }
                                                 }
@@ -4953,9 +4956,11 @@
                                 {
                                     "properties": {
                                         "aliquots": {
+                                            "description": "Ids of the aliquot(s) within this file.",
                                             "items": {
-                                                "$comment": "Ids of the aliquot(s) within this assay.",
+                                                "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                                 "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                 "type": "string"
                                             },
                                             "type": "array"
@@ -4965,7 +4970,7 @@
                                             "description": "Data format."
                                         },
                                         "number_of_aliquots": {
-                                            "description": "Number of aliquots within this assay.",
+                                            "description": "Number of aliquots within this file.",
                                             "type": "integer"
                                         }
                                     }
@@ -5133,8 +5138,9 @@
                                             "type": "integer"
                                         },
                                         "cimac_aliquot_id": {
-                                            "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                            "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                             "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                             "type": "string"
                                         },
                                         "cimac_participant_id": {
@@ -7265,8 +7271,9 @@
                                             "type": "integer"
                                         },
                                         "cimac_aliquot_id": {
-                                            "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                            "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                             "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                             "type": "string"
                                         },
                                         "cimac_participant_id": {

--- a/docs/docs/assays.components.cytof.cytof_entry.html
+++ b/docs/docs/assays.components.cytof.cytof_entry.html
@@ -1166,8 +1166,9 @@
             "type": "string"
         },
         "cimac_aliquot_id": {
-            "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+            "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
             "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
             "type": "string"
         },
         "cimac_participant_id": {

--- a/docs/docs/assays.components.ngs.ngs_assay_record.html
+++ b/docs/docs/assays.components.ngs.ngs_assay_record.html
@@ -364,8 +364,9 @@
             "type": "integer"
         },
         "cimac_aliquot_id": {
-            "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+            "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
             "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
             "type": "string"
         },
         "cimac_participant_id": {

--- a/docs/docs/assays.components.ngs.rna_expression_entry.html
+++ b/docs/docs/assays.components.ngs.rna_expression_entry.html
@@ -242,8 +242,9 @@
                     "type": "integer"
                 },
                 "cimac_aliquot_id": {
-                    "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                     "type": "string"
                 },
                 "cimac_participant_id": {

--- a/docs/docs/assays.components.ngs.wes_assay_record.html
+++ b/docs/docs/assays.components.ngs.wes_assay_record.html
@@ -180,8 +180,9 @@
                     "type": "integer"
                 },
                 "cimac_aliquot_id": {
-                    "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                     "type": "string"
                 },
                 "cimac_participant_id": {

--- a/docs/docs/assays.components.ngs.wes_entry.html
+++ b/docs/docs/assays.components.ngs.wes_entry.html
@@ -180,8 +180,9 @@
                     "type": "integer"
                 },
                 "cimac_aliquot_id": {
-                    "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                     "type": "string"
                 },
                 "cimac_participant_id": {

--- a/docs/docs/assays.components.olink.olink_combined.html
+++ b/docs/docs/assays.components.olink.olink_combined.html
@@ -249,9 +249,11 @@
                 {
                     "properties": {
                         "aliquots": {
+                            "description": "Ids of the aliquot(s) within this file.",
                             "items": {
-                                "$comment": "Ids of the aliquot(s) within this assay.",
+                                "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                 "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                 "type": "string"
                             },
                             "type": "array"
@@ -261,7 +263,7 @@
                             "description": "Data format."
                         },
                         "number_of_aliquots": {
-                            "description": "Number of aliquots within this assay.",
+                            "description": "Number of aliquots within this file.",
                             "type": "integer"
                         }
                     }

--- a/docs/docs/assays.components.olink.olink_entry.html
+++ b/docs/docs/assays.components.olink.olink_entry.html
@@ -680,9 +680,11 @@
                         {
                             "properties": {
                                 "aliquots": {
+                                    "description": "Ids of the aliquot(s) within this file.",
                                     "items": {
-                                        "$comment": "Ids of the aliquot(s) within this assay.",
+                                        "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                         "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                        "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                         "type": "string"
                                     },
                                     "type": "array"
@@ -692,7 +694,7 @@
                                     "description": "Data format."
                                 },
                                 "number_of_aliquots": {
-                                    "description": "Number of aliquots within this assay.",
+                                    "description": "Number of aliquots within this file.",
                                     "type": "integer"
                                 }
                             }

--- a/docs/docs/assays.components.olink.olink_input.html
+++ b/docs/docs/assays.components.olink.olink_input.html
@@ -235,9 +235,11 @@
                 {
                     "properties": {
                         "aliquots": {
+                            "description": "Ids of the aliquot(s) within this file.",
                             "items": {
-                                "$comment": "Ids of the aliquot(s) within this assay.",
+                                "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                 "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                 "type": "string"
                             },
                             "type": "array"
@@ -247,7 +249,7 @@
                             "description": "Data format."
                         },
                         "number_of_aliquots": {
-                            "description": "Number of aliquots within this assay.",
+                            "description": "Number of aliquots within this file.",
                             "type": "integer"
                         }
                     }

--- a/docs/docs/assays.cytof_assay.html
+++ b/docs/docs/assays.cytof_assay.html
@@ -646,8 +646,9 @@
                         "type": "string"
                     },
                     "cimac_aliquot_id": {
-                        "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                        "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                         "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                        "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                         "type": "string"
                     },
                     "cimac_participant_id": {

--- a/docs/docs/assays.olink_assay.html
+++ b/docs/docs/assays.olink_assay.html
@@ -346,9 +346,11 @@
                                     {
                                         "properties": {
                                             "aliquots": {
+                                                "description": "Ids of the aliquot(s) within this file.",
                                                 "items": {
-                                                    "$comment": "Ids of the aliquot(s) within this assay.",
+                                                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                     "type": "string"
                                                 },
                                                 "type": "array"
@@ -358,7 +360,7 @@
                                                 "description": "Data format."
                                             },
                                             "number_of_aliquots": {
-                                                "description": "Number of aliquots within this assay.",
+                                                "description": "Number of aliquots within this file.",
                                                 "type": "integer"
                                             }
                                         }
@@ -693,9 +695,11 @@
                         {
                             "properties": {
                                 "aliquots": {
+                                    "description": "Ids of the aliquot(s) within this file.",
                                     "items": {
-                                        "$comment": "Ids of the aliquot(s) within this assay.",
+                                        "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                         "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                        "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                         "type": "string"
                                     },
                                     "type": "array"
@@ -705,7 +709,7 @@
                                     "description": "Data format."
                                 },
                                 "number_of_aliquots": {
-                                    "description": "Number of aliquots within this assay.",
+                                    "description": "Number of aliquots within this file.",
                                     "type": "integer"
                                 }
                             }

--- a/docs/docs/assays.rna_expression_assay.html
+++ b/docs/docs/assays.rna_expression_assay.html
@@ -457,8 +457,9 @@
                                 "type": "integer"
                             },
                             "cimac_aliquot_id": {
-                                "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                 "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                 "type": "string"
                             },
                             "cimac_participant_id": {

--- a/docs/docs/assays.wes_assay.html
+++ b/docs/docs/assays.wes_assay.html
@@ -1516,8 +1516,9 @@
                                 "type": "integer"
                             },
                             "cimac_aliquot_id": {
-                                "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                 "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                 "type": "string"
                             },
                             "cimac_participant_id": {

--- a/docs/docs/clinical_trial.html
+++ b/docs/docs/clinical_trial.html
@@ -894,8 +894,9 @@
                                             "type": "string"
                                         },
                                         "cimac_aliquot_id": {
-                                            "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                            "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                             "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                            "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                             "type": "string"
                                         },
                                         "cimac_participant_id": {
@@ -4709,9 +4710,11 @@
                                                     {
                                                         "properties": {
                                                             "aliquots": {
+                                                                "description": "Ids of the aliquot(s) within this file.",
                                                                 "items": {
-                                                                    "$comment": "Ids of the aliquot(s) within this assay.",
+                                                                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                                                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                                     "type": "string"
                                                                 },
                                                                 "type": "array"
@@ -4721,7 +4724,7 @@
                                                                 "description": "Data format."
                                                             },
                                                             "number_of_aliquots": {
-                                                                "description": "Number of aliquots within this assay.",
+                                                                "description": "Number of aliquots within this file.",
                                                                 "type": "integer"
                                                             }
                                                         }
@@ -5056,9 +5059,11 @@
                                         {
                                             "properties": {
                                                 "aliquots": {
+                                                    "description": "Ids of the aliquot(s) within this file.",
                                                     "items": {
-                                                        "$comment": "Ids of the aliquot(s) within this assay.",
+                                                        "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Ids of the aliquot(s) within this file.",
                                                         "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                        "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                         "type": "string"
                                                     },
                                                     "type": "array"
@@ -5068,7 +5073,7 @@
                                                     "description": "Data format."
                                                 },
                                                 "number_of_aliquots": {
-                                                    "description": "Number of aliquots within this assay.",
+                                                    "description": "Number of aliquots within this file.",
                                                     "type": "integer"
                                                 }
                                             }
@@ -5236,8 +5241,9 @@
                                                     "type": "integer"
                                                 },
                                                 "cimac_aliquot_id": {
-                                                    "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                     "type": "string"
                                                 },
                                                 "cimac_participant_id": {
@@ -7368,8 +7374,9 @@
                                                     "type": "integer"
                                                 },
                                                 "cimac_aliquot_id": {
-                                                    "$comment": "Id of an aliquot within this clinical trial, that this assay record is based upon.",
+                                                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.Id of an aliquot within this clinical trial, that this assay record is based upon.",
                                                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                     "type": "string"
                                                 },
                                                 "cimac_participant_id": {
@@ -7946,7 +7953,9 @@
                                                 "type": "string"
                                             },
                                             "cimac_aliquot_id": {
+                                                "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.",
                                                 "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                                "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                                 "type": "string"
                                             },
                                             "extracted_concentration": {

--- a/docs/docs/participant.html
+++ b/docs/docs/participant.html
@@ -496,7 +496,9 @@
                                     "type": "string"
                                 },
                                 "cimac_aliquot_id": {
+                                    "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.",
                                     "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                                    "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                                     "type": "string"
                                 },
                                 "extracted_concentration": {

--- a/docs/docs/sample.html
+++ b/docs/docs/sample.html
@@ -739,7 +739,9 @@
                         "type": "string"
                     },
                     "cimac_aliquot_id": {
+                        "$comment": "With `in_doc_ref_pattern` here, there's no need to specify it each time cimac_aliquot_id is $refed, constrain will be pulled in place by ref resolver automatically, assuring that it will be checked for every cimac_aliquot_id $ref.",
                         "description": "Aliquot identifier assigned by the CIMAC-CIDC Network. Example: CIMAC-12453.",
+                        "in_doc_ref_pattern": "/participants/*/samples/*/aliquots/*/cimac_aliquot_id",
                         "type": "string"
                     },
                     "extracted_concentration": {


### PR DESCRIPTION
this way we don't need to specify it each time it's $ref'ed - it will be pulled in place by ref resolver