### PR TITLE
Unprism (patient + sample CSVs)

### DIFF
--- a/cidc_schemas/unprism.py
+++ b/cidc_schemas/unprism.py
@@ -8,7 +8,7 @@ def unprism_participants(trial_metadata: dict):
 
     participants.drop('samples', axis=1, inplace=True)
 
-    return participants.to_csv()
+    return participants.to_csv(index=False)
 
 
 def unprism_samples(assay_type: str):
@@ -18,4 +18,4 @@ def unprism_samples(assay_type: str):
 
     samples.drop('aliquots', axis=1, inplace=True)
 
-    return samples.to_csv()
+    return samples.to_csv(index=False)

--- a/cidc_schemas/unprism.py
+++ b/cidc_schemas/unprism.py
@@ -1,25 +1,21 @@
 from pandas.io.json import json_normalize
 
 
-def unprism_participants(json):
-    """ Returns csv content as string.
+def unprism_participants(trial_metadata: dict):
+    """Return a CSV of patient-level metadata for the given trial."""
+    participants = json_normalize(data=trial_metadata, record_path=['participants'],
+                                  meta=['lead_organization_study_id'])
 
-    >>> print(unprism_participants({"participants": [{"arm_id": "12345", "gender": "Male", "samples":[], "cohort_id": "54321", "cimac_participant_id": "PA1", "trial_participant_id": "tPA1"}, {"race": "White", "gender":"Other", "arm_id": "12345", "samples":[], "cohort_id": "54321", "cimac_participant_id": "PA2", "trial_participant_id": "tPA2"}], "lead_organization_study_id": "test_trial_id#"}))
-    ,arm_id,gender,samples,cohort_id,cimac_participant_id,trial_participant_id,race,lead_organization_study_id
-    0,12345,Male,[],54321,PA1,tPA1,,test_trial_id#
-    1,12345,Other,[],54321,PA2,tPA2,White,test_trial_id#
-    <BLANKLINE>
+    participants.drop('samples', axis=1, inplace=True)
 
-    """
-    return json_normalize(data=json, record_path=['participants'],
-                            meta=['lead_organization_study_id']).to_csv()
+    return participants.to_csv()
 
 
-def unprism_assay_samples(assay_type: str, json):
-    """
-    >>> print(unprism_assay_samples("cytof" ,{"assays": {"cytof": [{"records": [{"files": {"source_fcs": [{"md5_hash": "1B2M2Y8AsgTpgAmY7PhCfg==", "file_name": "cytof", "object_url": "staging_0/test/test/PA2SA1-al5/cytof/source_0.fcs", "data_format": "BINARY", "file_size_bytes": 0, "artifact_category": "Assay Artifact from CIMAC", "upload_placeholder": "e34b0f01-c980-405f-b97c-c7de4dd80ede", "uploaded_timestamp": "2019-09-23T15:40:16.307000+00:00"}], "processed_fcs": {"md5_hash": "1B2M2Y8AsgTpgAmY7PhCfg==", "file_name": "cytof", "object_url": "staging_0/test/test/PA2SA1-al5/cytof/processed.fcs", "data_format": "BINARY", "file_size_bytes": 0, "artifact_category": "Assay Artifact from CIMAC", "upload_placeholder": "c7118184-d3ce-44d7-a773-2870edfa6431", "uploaded_timestamp": "2019-09-23T15:40:19.104000+00:00"}}, "batch_id": "test", "injector": "sdf", "run_time": "7", "beads_removed": "Y", "cimac_sample_id": "test", "debarcoding_key": "dfg", "cimac_aliquot_id": "PA2SA1-al5", "acquisition_buffer": "sdf", "date_of_acquisition": "2012-12-12 00:00:00", "preprocessing_notes": "dfg", "cimac_participant_id": "test", "debarcoding_protocol": "dfg", "concatenation_version": "5", "normalization_version": "5", "average_event_per_second": 7.0}], "instrument": "sdf", "panel_name": "sdf", "assay_creator": "DFCI", "cytof_antibodies": [{"clone": "dfg", "usage": "Ignored", "cat_num": "123", "company": "dfg", "isotope": "123", "lot_num": "123", "antibody": "dfg", "dilution": "123", "stain_type": "Surface Stain"}]}]}}))
-    True
+def unprism_samples(assay_type: str):
+    """Return a CSV of patient-level metadata for the given trial."""
+    samples = json_normalize(data=assay_type, record_path=['participants', "samples"],
+                             meta=["lead_organization_study_id", ["participants", "cimac_participant_id"]])
 
-    """
-    return json_normalize(data=json, record_path=['assays', assay_type, "records"],
-                            meta=[]).to_csv()
+    samples.drop('aliquots', axis=1, inplace=True)
+
+    return samples.to_csv()

--- a/cidc_schemas/unprism.py
+++ b/cidc_schemas/unprism.py
@@ -1,0 +1,25 @@
+from pandas.io.json import json_normalize
+
+
+def unprism_participants(json):
+    """ Returns csv content as string.
+
+    >>> print(unprism_participants({"participants": [{"arm_id": "12345", "gender": "Male", "samples":[], "cohort_id": "54321", "cimac_participant_id": "PA1", "trial_participant_id": "tPA1"}, {"race": "White", "gender":"Other", "arm_id": "12345", "samples":[], "cohort_id": "54321", "cimac_participant_id": "PA2", "trial_participant_id": "tPA2"}], "lead_organization_study_id": "test_trial_id#"}))
+    ,arm_id,gender,samples,cohort_id,cimac_participant_id,trial_participant_id,race,lead_organization_study_id
+    0,12345,Male,[],54321,PA1,tPA1,,test_trial_id#
+    1,12345,Other,[],54321,PA2,tPA2,White,test_trial_id#
+    <BLANKLINE>
+
+    """
+    return json_normalize(data=json, record_path=['participants'],
+                            meta=['lead_organization_study_id']).to_csv()
+
+
+def unprism_assay_samples(assay_type: str, json):
+    """
+    >>> print(unprism_assay_samples("cytof" ,{"assays": {"cytof": [{"records": [{"files": {"source_fcs": [{"md5_hash": "1B2M2Y8AsgTpgAmY7PhCfg==", "file_name": "cytof", "object_url": "staging_0/test/test/PA2SA1-al5/cytof/source_0.fcs", "data_format": "BINARY", "file_size_bytes": 0, "artifact_category": "Assay Artifact from CIMAC", "upload_placeholder": "e34b0f01-c980-405f-b97c-c7de4dd80ede", "uploaded_timestamp": "2019-09-23T15:40:16.307000+00:00"}], "processed_fcs": {"md5_hash": "1B2M2Y8AsgTpgAmY7PhCfg==", "file_name": "cytof", "object_url": "staging_0/test/test/PA2SA1-al5/cytof/processed.fcs", "data_format": "BINARY", "file_size_bytes": 0, "artifact_category": "Assay Artifact from CIMAC", "upload_placeholder": "c7118184-d3ce-44d7-a773-2870edfa6431", "uploaded_timestamp": "2019-09-23T15:40:19.104000+00:00"}}, "batch_id": "test", "injector": "sdf", "run_time": "7", "beads_removed": "Y", "cimac_sample_id": "test", "debarcoding_key": "dfg", "cimac_aliquot_id": "PA2SA1-al5", "acquisition_buffer": "sdf", "date_of_acquisition": "2012-12-12 00:00:00", "preprocessing_notes": "dfg", "cimac_participant_id": "test", "debarcoding_protocol": "dfg", "concatenation_version": "5", "normalization_version": "5", "average_event_per_second": 7.0}], "instrument": "sdf", "panel_name": "sdf", "assay_creator": "DFCI", "cytof_antibodies": [{"clone": "dfg", "usage": "Ignored", "cat_num": "123", "company": "dfg", "isotope": "123", "lot_num": "123", "antibody": "dfg", "dilution": "123", "stain_type": "Surface Stain"}]}]}}))
+    True
+
+    """
+    return json_normalize(data=json, record_path=['assays', assay_type, "records"],
+                            meta=[]).to_csv()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ openpyxl==2.6.2
 jsonmerge==1.6.1
 deepdiff==4.0.6
 jsonpointer==2.0
+pandas==0.25.1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.4.14',
+    version='0.4.15',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/test_unprism.py
+++ b/tests/test_unprism.py
@@ -1,0 +1,101 @@
+from cidc_schemas.unprism import unprism_participants, unprism_samples
+
+
+def test_unprism_participants():
+    """Check that we can extract patient-level data from a trial metadata object."""
+    trial_metadata = {
+        "lead_organization_study_id": "test_trial_id",
+        "participants": [
+            {
+                "arm_id": "12345",
+                "gender": "Male",
+                "samples": [],
+                "cohort_id": "54321",
+                "cimac_participant_id": "PA1",
+                "trial_participant_id": "tPA1"
+            },
+            {
+                "race": "White",
+                "gender": "Other",
+                "arm_id": "12345",
+                "samples": [],
+                "cohort_id": "54321",
+                "cimac_participant_id": "PA2",
+                "trial_participant_id": "tPA2"
+            }
+        ],
+    }
+
+    csv = unprism_participants(trial_metadata)
+    expected = """,arm_id,gender,cohort_id,cimac_participant_id,trial_participant_id,race,lead_organization_study_id
+        0,12345,Male,54321,PA1,tPA1,,test_trial_id
+        1,12345,Other,54321,PA2,tPA2,White,test_trial_id
+    """.replace(" ", "")
+    assert csv == expected
+
+
+def test_unprism_samples():
+    """
+    Check that we can extract sample-level data from a trial metadata object with multiple
+    participants and different properties in different samples.
+    """
+    trial_metadata = {
+        "lead_organization_study_id": "1/minimal",
+        "participants": [
+            {
+                "cimac_participant_id": "PA.1.1",
+                "samples": [
+                    {
+                        "cimac_id": "SA.1.1.1",
+                        "site_sample_id": "site.SA.1.1.1",
+                        "time_point": "---",
+                        "sample_location": "---",
+                        "specimen_type": "Other",
+                        "specimen_format": "Other",
+                        "genomic_source": "Normal",
+                        "aliquots": []
+                    },
+                    {
+                        "cimac_id": "SA.1.1.2",
+                        "site_sample_id": "site.SA.1.1.2",
+                        "time_point": "---",
+                        "specimen_type": "plasma",
+                        "aliquots": []
+                    }
+                ]
+            },
+            {
+                "cimac_participant_id": "PA.1.2",
+                "samples": [
+                    {
+                        "cimac_id": "SA.1.2.1",
+                        "site_sample_id": "site.SA.1.2.1",
+                        "time_point": "---",
+                        "sample_location": "---",
+                        "specimen_type": "Other",
+                        "specimen_format": "Other",
+                        "genomic_source": "Normal",
+                        "aliquots": []
+                    },
+                    {
+                        "cimac_id": "SA.1.2.2",
+                        "site_sample_id": "site.SA.1.2.2",
+                        "time_point": "---",
+                        "specimen_type": "pbmc",
+                        "aliquots": []
+                    }
+                ]
+            }
+        ]
+    }
+
+    csv = unprism_samples(trial_metadata)
+
+    expected = """,cimac_id,site_sample_id,time_point,sample_location,specimen_type,specimen_format,genomic_source,lead_organization_study_id,participants.cimac_participant_id
+        0,SA.1.1.1,site.SA.1.1.1,---,---,Other,Other,Normal,1/minimal,PA.1.1
+        1,SA.1.1.2,site.SA.1.1.2,---,,plasma,,,1/minimal,PA.1.1
+        2,SA.1.2.1,site.SA.1.2.1,---,---,Other,Other,Normal,1/minimal,PA.1.2
+        3,SA.1.2.2,site.SA.1.2.2,---,,pbmc,,,1/minimal,PA.1.2
+    """.replace(" ", "")
+
+    assert csv == expected

--- a/tests/test_unprism.py
+++ b/tests/test_unprism.py
@@ -1,4 +1,11 @@
 from cidc_schemas.unprism import unprism_participants, unprism_samples
+from cidc_schemas.json_validation import load_and_validate_schema
+
+
+def _validate_ct(ct: dict):
+    validator = load_and_validate_schema(
+        'clinical_trial.json', return_validator=True)
+    validator.validate(ct)
 
 
 def test_unprism_participants():
@@ -11,7 +18,7 @@ def test_unprism_participants():
                 "gender": "Male",
                 "samples": [],
                 "cohort_id": "54321",
-                "cimac_participant_id": "PA1",
+                "cimac_participant_id": "CM-TEST-PA11",
                 "trial_participant_id": "tPA1"
             },
             {
@@ -20,17 +27,21 @@ def test_unprism_participants():
                 "arm_id": "12345",
                 "samples": [],
                 "cohort_id": "54321",
-                "cimac_participant_id": "PA2",
+                "cimac_participant_id": "CM-TEST-PA12",
                 "trial_participant_id": "tPA2"
             }
         ],
     }
 
+    # Validate the trial_metadata object to ensure this test fails
+    # if the data model changes.
+    _validate_ct(trial_metadata)
+
     csv = unprism_participants(trial_metadata)
     expected = """,arm_id,gender,cohort_id,cimac_participant_id,trial_participant_id,race,lead_organization_study_id
-        0,12345,Male,54321,PA1,tPA1,,test_trial_id
-        1,12345,Other,54321,PA2,tPA2,White,test_trial_id
-    """.replace(" ", "")
+0,12345,Male,54321,CM-TEST-PA11,tPA1,,test_trial_id
+1,12345,Other,54321,CM-TEST-PA12,tPA2,White,test_trial_id
+"""
     assert csv == expected
 
 
@@ -39,14 +50,22 @@ def test_unprism_samples():
     Check that we can extract sample-level data from a trial metadata object with multiple
     participants and different properties in different samples.
     """
+
+    extra_participant_fields = {
+        "trial_participant_id": "",
+        "cohort_id": "",
+        "arm_id": "",
+    }
+
     trial_metadata = {
         "lead_organization_study_id": "1/minimal",
         "participants": [
             {
-                "cimac_participant_id": "PA.1.1",
+                "cimac_participant_id": "CM-TEST-PA11",
+                **extra_participant_fields,
                 "samples": [
                     {
-                        "cimac_id": "SA.1.1.1",
+                        "cimac_id": "CM-TEST-PA11-S1",
                         "site_sample_id": "site.SA.1.1.1",
                         "time_point": "---",
                         "sample_location": "---",
@@ -56,32 +75,39 @@ def test_unprism_samples():
                         "aliquots": []
                     },
                     {
-                        "cimac_id": "SA.1.1.2",
+                        "cimac_id": "CM-TEST-PA11-S2",
                         "site_sample_id": "site.SA.1.1.2",
                         "time_point": "---",
-                        "specimen_type": "plasma",
+                        "sample_location": "---",
+                        "specimen_format": "FFPE Block",
+                        "specimen_type": "Plasma",
+                        "genomic_source": "Tumor",
                         "aliquots": []
                     }
                 ]
             },
             {
-                "cimac_participant_id": "PA.1.2",
+                "cimac_participant_id": "CM-TEST-PA12",
+                **extra_participant_fields,
                 "samples": [
                     {
-                        "cimac_id": "SA.1.2.1",
+                        "cimac_id": "CM-TEST-PA12-S1",
                         "site_sample_id": "site.SA.1.2.1",
                         "time_point": "---",
                         "sample_location": "---",
                         "specimen_type": "Other",
-                        "specimen_format": "Other",
+                        "specimen_format": "EDTA Tube",
                         "genomic_source": "Normal",
                         "aliquots": []
                     },
                     {
-                        "cimac_id": "SA.1.2.2",
+                        "cimac_id": "CM-TEST-PA12-S2",
                         "site_sample_id": "site.SA.1.2.2",
                         "time_point": "---",
-                        "specimen_type": "pbmc",
+                        "sample_location": "---",
+                        "specimen_type": "PBMC",
+                        "specimen_format": "EDTA Tube",
+                        "genomic_source": "Tumor",
                         "aliquots": []
                     }
                 ]
@@ -89,13 +115,17 @@ def test_unprism_samples():
         ]
     }
 
+    # Validate the trial_metadata object to ensure this test fails
+    # if the data model changes.
+    _validate_ct(trial_metadata)
+
     csv = unprism_samples(trial_metadata)
 
     expected = """,cimac_id,site_sample_id,time_point,sample_location,specimen_type,specimen_format,genomic_source,lead_organization_study_id,participants.cimac_participant_id
-        0,SA.1.1.1,site.SA.1.1.1,---,---,Other,Other,Normal,1/minimal,PA.1.1
-        1,SA.1.1.2,site.SA.1.1.2,---,,plasma,,,1/minimal,PA.1.1
-        2,SA.1.2.1,site.SA.1.2.1,---,---,Other,Other,Normal,1/minimal,PA.1.2
-        3,SA.1.2.2,site.SA.1.2.2,---,,pbmc,,,1/minimal,PA.1.2
-    """.replace(" ", "")
+0,CM-TEST-PA11-S1,site.SA.1.1.1,---,---,Other,Other,Normal,1/minimal,CM-TEST-PA11
+1,CM-TEST-PA11-S2,site.SA.1.1.2,---,---,Plasma,FFPE Block,Tumor,1/minimal,CM-TEST-PA11
+2,CM-TEST-PA12-S1,site.SA.1.2.1,---,---,Other,EDTA Tube,Normal,1/minimal,CM-TEST-PA12
+3,CM-TEST-PA12-S2,site.SA.1.2.2,---,---,PBMC,EDTA Tube,Tumor,1/minimal,CM-TEST-PA12
+"""
 
     assert csv == expected

--- a/tests/test_unprism.py
+++ b/tests/test_unprism.py
@@ -1,131 +1,43 @@
+import os
+import json
+
+import pytest
+
 from cidc_schemas.unprism import unprism_participants, unprism_samples
-from cidc_schemas.json_validation import load_and_validate_schema
+
+ct_example_path = os.path.join(os.path.dirname(
+    __file__), 'data/clinicaltrial_examples/CT_1.json')
 
 
-def _validate_ct(ct: dict):
-    validator = load_and_validate_schema(
-        'clinical_trial.json', return_validator=True)
-    validator.validate(ct)
+@pytest.fixture
+def ct():
+    with open(ct_example_path, 'r') as ct:
+        yield json.load(ct)
 
 
-def test_unprism_participants():
+def test_unprism_participants(ct):
     """Check that we can extract patient-level data from a trial metadata object."""
-    trial_metadata = {
-        "lead_organization_study_id": "test_trial_id",
-        "participants": [
-            {
-                "arm_id": "12345",
-                "gender": "Male",
-                "samples": [],
-                "cohort_id": "54321",
-                "cimac_participant_id": "CM-TEST-PA11",
-                "trial_participant_id": "tPA1"
-            },
-            {
-                "race": "White",
-                "gender": "Other",
-                "arm_id": "12345",
-                "samples": [],
-                "cohort_id": "54321",
-                "cimac_participant_id": "CM-TEST-PA12",
-                "trial_participant_id": "tPA2"
-            }
-        ],
-    }
+    csv = unprism_participants(ct)
 
-    # Validate the trial_metadata object to ensure this test fails
-    # if the data model changes.
-    _validate_ct(trial_metadata)
+    expected = (
+        "cimac_participant_id,trial_participant_id,cohort_id,arm_id,lead_organization_study_id\n"
+        "CM-TEST-PAR1,trial.PA.1,---,---,10021\n"
+        "CM-TEST-PAR2,trial.PA.2,---,---,10021\n"
+    )
 
-    csv = unprism_participants(trial_metadata)
-    expected = """,arm_id,gender,cohort_id,cimac_participant_id,trial_participant_id,race,lead_organization_study_id
-0,12345,Male,54321,CM-TEST-PA11,tPA1,,test_trial_id
-1,12345,Other,54321,CM-TEST-PA12,tPA2,White,test_trial_id
-"""
     assert csv == expected
 
 
-def test_unprism_samples():
-    """
-    Check that we can extract sample-level data from a trial metadata object with multiple
-    participants and different properties in different samples.
-    """
+def test_unprism_samples(ct):
+    """Check that we can extract sample-level data from a trial metadata object."""
+    csv = unprism_samples(ct)
 
-    extra_participant_fields = {
-        "trial_participant_id": "",
-        "cohort_id": "",
-        "arm_id": "",
-    }
-
-    trial_metadata = {
-        "lead_organization_study_id": "1/minimal",
-        "participants": [
-            {
-                "cimac_participant_id": "CM-TEST-PA11",
-                **extra_participant_fields,
-                "samples": [
-                    {
-                        "cimac_id": "CM-TEST-PA11-S1",
-                        "site_sample_id": "site.SA.1.1.1",
-                        "time_point": "---",
-                        "sample_location": "---",
-                        "specimen_type": "Other",
-                        "specimen_format": "Other",
-                        "genomic_source": "Normal",
-                        "aliquots": []
-                    },
-                    {
-                        "cimac_id": "CM-TEST-PA11-S2",
-                        "site_sample_id": "site.SA.1.1.2",
-                        "time_point": "---",
-                        "sample_location": "---",
-                        "specimen_format": "FFPE Block",
-                        "specimen_type": "Plasma",
-                        "genomic_source": "Tumor",
-                        "aliquots": []
-                    }
-                ]
-            },
-            {
-                "cimac_participant_id": "CM-TEST-PA12",
-                **extra_participant_fields,
-                "samples": [
-                    {
-                        "cimac_id": "CM-TEST-PA12-S1",
-                        "site_sample_id": "site.SA.1.2.1",
-                        "time_point": "---",
-                        "sample_location": "---",
-                        "specimen_type": "Other",
-                        "specimen_format": "EDTA Tube",
-                        "genomic_source": "Normal",
-                        "aliquots": []
-                    },
-                    {
-                        "cimac_id": "CM-TEST-PA12-S2",
-                        "site_sample_id": "site.SA.1.2.2",
-                        "time_point": "---",
-                        "sample_location": "---",
-                        "specimen_type": "PBMC",
-                        "specimen_format": "EDTA Tube",
-                        "genomic_source": "Tumor",
-                        "aliquots": []
-                    }
-                ]
-            }
-        ]
-    }
-
-    # Validate the trial_metadata object to ensure this test fails
-    # if the data model changes.
-    _validate_ct(trial_metadata)
-
-    csv = unprism_samples(trial_metadata)
-
-    expected = """,cimac_id,site_sample_id,time_point,sample_location,specimen_type,specimen_format,genomic_source,lead_organization_study_id,participants.cimac_participant_id
-0,CM-TEST-PA11-S1,site.SA.1.1.1,---,---,Other,Other,Normal,1/minimal,CM-TEST-PA11
-1,CM-TEST-PA11-S2,site.SA.1.1.2,---,---,Plasma,FFPE Block,Tumor,1/minimal,CM-TEST-PA11
-2,CM-TEST-PA12-S1,site.SA.1.2.1,---,---,Other,EDTA Tube,Normal,1/minimal,CM-TEST-PA12
-3,CM-TEST-PA12-S2,site.SA.1.2.2,---,---,PBMC,EDTA Tube,Tumor,1/minimal,CM-TEST-PA12
-"""
+    expected = (
+        "cimac_id,site_sample_id,time_point,sample_location,specimen_type,specimen_format,genomic_source,lead_organization_study_id,participants.cimac_participant_id\n"
+        "CM-TEST-PAR1-S1,SA.1.1,---,---,Other,Other,Tumor,10021,CM-TEST-PAR1\n"
+        "CM-TEST-PAR1-S2,SA.1.2,---,---,Other,Other,Normal,10021,CM-TEST-PAR1\n"
+        "CM-TEST-PAR2-S1,SA.2.1,---,---,Other,Other,Tumor,10021,CM-TEST-PAR2\n"
+        "CM-TEST-PAR2-S2,SA.2.2,---,---,Other,Other,Normal,10021,CM-TEST-PAR2\n"
+    )
 
     assert csv == expected


### PR DESCRIPTION
Introduces the `unprism` model, which uses pandas to extract normalized participant- and sample-level data from trial metadata JSON objects.