### PR TITLE
Artifact specific metadata

### DIFF
--- a/cidc_schemas/util.py
+++ b/cidc_schemas/util.py
@@ -69,12 +69,7 @@ def split_python_style_path(path: str) -> list:
         yield groups[2] or int(groups[1])
 
 
-def get_source(
-    ct: dict,
-    key: str,
-    skip_last=None,
-    key_filter=lambda k: not k.startswith('__')
-) -> (JSON, JSON):
+def get_source(ct: dict, key: str, skip_last=None) -> (JSON, JSON):
     """
     extract the object in the dictionary specified by
     the supplied key (or one of its parents.)
@@ -83,8 +78,6 @@ def get_source(
         ct: clinical_trial object to be searched
         key: the identifier we are looking for in the dictionary,
         skip_last: how many levels at the end of key path we want to skip.
-        key_filter: a function that returns true if a key should be included in
-            extra metadata.
     Returns:
         arg1: the value present in `ct` at the `key` path
         arg2: extra metadata collected while descending down `key` path
@@ -104,7 +97,7 @@ def get_source(
             # We collect every primitive value present on `cur_obj`
             # with keys that aren't the `token` key we are looking for
             for k, v in cur_obj.items():
-                if isinstance(v, (int, float, str)) and k != token and key_filter(k):
+                if isinstance(v, (int, float, str)) and k != token:
                     extra_metadata[k] = v
         cur_obj = cur_obj[token]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.6.2',
+    version='0.7.0',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -583,7 +583,7 @@ def test_merge_artifact_wes_only():
     for url, uuid in WES_TEMPLATE_EXAMPLE_GS_URLS.items():
 
         # attempt to merge
-        ct, artifact = merge_artifact(
+        ct, artifact, patch_metadata = merge_artifact(
                 ct,
                 assay_type="wes",
                 artifact_uuid=uuid,
@@ -762,7 +762,7 @@ def test_end_to_end_prismify_merge_artifact_merge(schema_path, xlsx_path):
     for i, fmap_entry in enumerate(file_maps):
 
         # attempt to merge
-        patch_copy_4_artifacts, artifact = merge_artifact(
+        patch_copy_4_artifacts, artifact, patch_metadata = merge_artifact(
                 patch_copy_4_artifacts,
                 artifact_uuid=fmap_entry.upload_placeholder,
                 object_url=fmap_entry.gs_key,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -94,13 +94,3 @@ def test_get_source_with_strings_with_quotes():
     assert "this", {'and " ': 'that'} == util.get_source(
         hier, "root['p'][0]['a'][0]['i want ' ']")
     assert "that", {} == util.get_source(hier, "root['p'][0]['and \" ']")
-
-
-def test_get_source_extra_metadata_filter():
-    """Ensure keys are omitted from source extra_metadata based on filters"""
-    hier = {
-        "a": {"1": "i", "__2": "ii", "3": "iii"},
-        "__b": 1
-    }
-
-    assert "i", {"3": "iii"} == util.get_source(hier, "root['a']['1']")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,10 +5,13 @@ import cidc_schemas.util as util
 
 from .constants import TEST_DATA_DIR
 
+
 def test_split_python_style_path():
 
-    assert ['p', 0, 'a', 0, 'id'] == list(util.split_python_style_path("root['p'][0]['a'][0]['id']"))
-    assert ['p', 0, 1, 2, 'id'] == list(util.split_python_style_path("root['p'][0][1][2]['id']"))
+    assert ['p', 0, 'a', 0, 'id'] == list(
+        util.split_python_style_path("root['p'][0]['a'][0]['id']"))
+    assert ['p', 0, 1, 2, 'id'] == list(
+        util.split_python_style_path("root['p'][0][1][2]['id']"))
 
 
 def test_get_all_paths():
@@ -18,12 +21,12 @@ def test_get_all_paths():
                 "id": 1,
                 "i want": "this"
             },
-            {
+                {
                 "id": 2,
                 "and": "this"
             }],
-            "id" : "3",
-            "and" : "this"
+            "id": "3",
+            "and": "this"
         }]
     }
 
@@ -32,14 +35,14 @@ def test_get_all_paths():
     assert ["root['p'][0]['id']"] == list(util.get_all_paths(hier, "3"))
     with pytest.raises(KeyError):
         assert (util.get_all_paths(hier, 3))
-    
+
     assert ["root[0]['id']"] == list(util.get_all_paths(hier['p'], "3"))
 
     assert [
         "root['p'][0]['a'][0]['i want']",
         "root['p'][0]['a'][1]['and']",
         "root['p'][0]['and']"
-        ] == sorted(list(util.get_all_paths(hier, "this")))
+    ] == sorted(list(util.get_all_paths(hier, "this")))
 
 
 def test_get_path_with_strings_with_quotes():
@@ -48,13 +51,12 @@ def test_get_path_with_strings_with_quotes():
             "a": [{
                 "i want ' ": "this"
             }],
-            "and \" " : "that"
+            "and \" ": "that"
         }]
     }
 
     assert "root['p'][0]['a'][0]['i want ' ']" == util.get_path(hier, "this")
     assert "root['p'][0]['and \" ']" == util.get_path(hier, "that")
-
 
 
 def test_get_source():
@@ -64,19 +66,19 @@ def test_get_source():
             "a": [{
                 "id": 1
             },
-            {
+                {
                 "id": 2
             }],
-            "id" : "3"
+            "id": "3"
         }]
     }
 
     assert 1, {"id": 3} == util.get_source(hier, "root['p'][0]['a'][0]['id']")
     assert 2, {"id": 3} == util.get_source(hier, "root['p'][0]['a'][1]['id']")
     assert '3', {} == util.get_source(hier, "root['p'][0]['id']")
-    
-    assert util.get_source(hier, "root['p'][0]['a'][1]['id']", skip_last=3) == util.get_source(hier, "root['p'][0]")
 
+    assert util.get_source(
+        hier, "root['p'][0]['a'][1]['id']", skip_last=3) == util.get_source(hier, "root['p'][0]")
 
 
 def test_get_source_with_strings_with_quotes():
@@ -85,11 +87,20 @@ def test_get_source_with_strings_with_quotes():
             "a": [{
                 "i want ' ": "this"
             }],
-            "and \" " : "that"
+            "and \" ": "that"
         }]
     }
 
-    assert  "this", {'and " ': 'that'} == util.get_source(hier, "root['p'][0]['a'][0]['i want ' ']")
-    assert  "that", {} == util.get_source(hier, "root['p'][0]['and \" ']")
+    assert "this", {'and " ': 'that'} == util.get_source(
+        hier, "root['p'][0]['a'][0]['i want ' ']")
+    assert "that", {} == util.get_source(hier, "root['p'][0]['and \" ']")
 
 
+def test_get_source_extra_metadata_filter():
+    """Ensure keys are omitted from source extra_metadata based on filters"""
+    hier = {
+        "a": {"1": "i", "__2": "ii", "3": "iii"},
+        "__b": 1
+    }
+
+    assert "i", {"3": "iii"} == util.get_source(hier, "root['a']['1']")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,9 +71,9 @@ def test_get_source():
         }]
     }
 
-    assert 1 == util.get_source(hier, "root['p'][0]['a'][0]['id']")
-    assert 2 == util.get_source(hier, "root['p'][0]['a'][1]['id']")
-    assert '3' == util.get_source(hier, "root['p'][0]['id']")
+    assert 1, {"id": 3} == util.get_source(hier, "root['p'][0]['a'][0]['id']")
+    assert 2, {"id": 3} == util.get_source(hier, "root['p'][0]['a'][1]['id']")
+    assert '3', {} == util.get_source(hier, "root['p'][0]['id']")
     
     assert util.get_source(hier, "root['p'][0]['a'][1]['id']", skip_last=3) == util.get_source(hier, "root['p'][0]")
 
@@ -89,7 +89,7 @@ def test_get_source_with_strings_with_quotes():
         }]
     }
 
-    assert  "this" == util.get_source(hier, "root['p'][0]['a'][0]['i want ' ']")
-    assert  "that" == util.get_source(hier, "root['p'][0]['and \" ']")
+    assert  "this", {'and " ': 'that'} == util.get_source(hier, "root['p'][0]['a'][0]['i want ' ']")
+    assert  "that", {} == util.get_source(hier, "root['p'][0]['and \" ']")
 
 


### PR DESCRIPTION
Updates the `get_source` method (and consequently `merge_artifact` and `merge_artifact_extra_metadata`) to collect additional trial-, assay-, and artifact-level metadata and return it.