### PR TITLE
Artifact specific metadata fixes

### DIFF
--- a/cidc_schemas/util.py
+++ b/cidc_schemas/util.py
@@ -97,7 +97,13 @@ def get_source(ct: dict, key: str, skip_last=None) -> (JSON, JSON):
             # We collect every primitive value present on `cur_obj`
             # with keys that aren't the `token` key we are looking for
             for k, v in cur_obj.items():
+
+
+<< << << < HEAD
                 if isinstance(v, (int, float, str)) and k != token:
+== == == =
+                if isinstance(v, (int, float, str)) and k != token and key_filter(k):
+>>>>>> > Collect artifact metadata while finding artifact records
                     extra_metadata[k] = v
         cur_obj = cur_obj[token]
 

--- a/cidc_schemas/util.py
+++ b/cidc_schemas/util.py
@@ -97,13 +97,7 @@ def get_source(ct: dict, key: str, skip_last=None) -> (JSON, JSON):
             # We collect every primitive value present on `cur_obj`
             # with keys that aren't the `token` key we are looking for
             for k, v in cur_obj.items():
-
-
-<< << << < HEAD
                 if isinstance(v, (int, float, str)) and k != token:
-== == == =
-                if isinstance(v, (int, float, str)) and k != token and key_filter(k):
->>>>>> > Collect artifact metadata while finding artifact records
                     extra_metadata[k] = v
         cur_obj = cur_obj[token]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(include=['cidc_schemas']),
     test_suite='tests',
     url='https://github.com/CIMAC-CIDC/schemas',
-    version='0.7.0',
+    version='0.7.1',
     zip_safe=False,
     entry_points={
         'console_scripts': ['cidc_schemas=cidc_schemas.cli:main']

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -772,6 +772,7 @@ def test_end_to_end_prismify_merge_artifact_merge(schema_path, xlsx_path):
                 md5_hash=f"hash_{i}"
             )
 
+
         # check that the data_format was set
         assert 'data_format' in artifact
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -73,9 +73,12 @@ def test_get_source():
         }]
     }
 
-    assert 1, {"id": 3} == util.get_source(hier, "root['p'][0]['a'][0]['id']")
-    assert 2, {"id": 3} == util.get_source(hier, "root['p'][0]['a'][1]['id']")
-    assert '3', {} == util.get_source(hier, "root['p'][0]['id']")
+    assert (1, {"p.id": "3"}) == util.get_source(
+        hier, "root['p'][0]['a'][0]['id']")
+    assert (2, {"p.id": "3"}) == util.get_source(
+        hier, "root['p'][0]['a'][1]['id']")
+    assert ('3', {"p.a": [{"id": 1}, {"id": 2}]}
+            ) == util.get_source(hier, "root['p'][0]['id']")
 
     assert util.get_source(
         hier, "root['p'][0]['a'][1]['id']", skip_last=3) == util.get_source(hier, "root['p'][0]")
@@ -91,9 +94,10 @@ def test_get_source_with_strings_with_quotes():
         }]
     }
 
-    assert "this", {'and " ': 'that'} == util.get_source(
+    assert ("this", {'p.and " ': 'that'}) == util.get_source(
         hier, "root['p'][0]['a'][0]['i want ' ']")
-    assert "that", {} == util.get_source(hier, "root['p'][0]['and \" ']")
+    assert ("that", {"p.a": [{"i want ' ": "this"}]}) == util.get_source(
+        hier, "root['p'][0]['and \" ']")
 
 
 def test_get_source_extra_metadata():
@@ -108,7 +112,7 @@ def test_get_source_extra_metadata():
     assert util.get_source(hier, "root['b'][0]['b']") == (
         2, {'a': 'foo', 'b.a': 1})
 
-    # Non-primitive values at the "artifact" level
+    # Collect non-primitive values at the lowest level
     hier = {
         "a": 'foo',
         "b": [{"a": [1, 2, 3], "b": 2, "c": {"foo": "bar"}}]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -80,8 +80,10 @@ def test_get_source():
     assert ('3', {"p.a": [{"id": 1}, {"id": 2}]}
             ) == util.get_source(hier, "root['p'][0]['id']")
 
-    assert util.get_source(
-        hier, "root['p'][0]['a'][1]['id']", skip_last=3) == util.get_source(hier, "root['p'][0]")
+    obj, extra_md = util.get_source(
+        hier, "root['p'][0]['a'][1]['id']", skip_last=3)
+    assert obj == util.get_source(hier, "root['p'][0]")[0]
+    assert extra_md == {"p.id": "3"}
 
 
 def test_get_source_with_strings_with_quotes():
@@ -120,3 +122,8 @@ def test_get_source_extra_metadata():
     assert util.get_source(hier, "root['b'][0]['b']") == (
         2, {'a': 'foo', 'b.a': [1, 2, 3], 'b.c': {"foo": "bar"}}
     )
+
+    # Handle skip_last
+    assert util.get_source(hier, "root['b'][0]['a']", skip_last=1)[1] == {
+        'a': 'foo', 'b.b': 2, 'b.c': {"foo": "bar"}
+    }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -94,3 +94,25 @@ def test_get_source_with_strings_with_quotes():
     assert "this", {'and " ': 'that'} == util.get_source(
         hier, "root['p'][0]['a'][0]['i want ' ']")
     assert "that", {} == util.get_source(hier, "root['p'][0]['and \" ']")
+
+
+def test_get_source_extra_metadata():
+    """
+    Check special cases handled by the extra_metadata functionality in get_source
+    """
+    # Duplicate keys across the hierarchy
+    hier = {
+        "a": 'foo',
+        "b": [{"a": 1, "b": 2}]
+    }
+    assert util.get_source(hier, "root['b'][0]['b']") == (
+        2, {'a': 'foo', 'b.a': 1})
+
+    # Non-primitive values at the "artifact" level
+    hier = {
+        "a": 'foo',
+        "b": [{"a": [1, 2, 3], "b": 2, "c": {"foo": "bar"}}]
+    }
+    assert util.get_source(hier, "root['b'][0]['b']") == (
+        2, {'a': 'foo', 'b.a': [1, 2, 3], 'b.c': {"foo": "bar"}}
+    )


### PR DESCRIPTION
Catches some corner cases that I missed in #195:
* namespacing to prevent collisions in property names across the metadata hierarchy
* allow non-primitive types at the artifact level in `get_source` (e.g., NPX files have a `samples` array of CIMAC IDs)