### PR TITLE
Bump version so that new dependency structure is deployed

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.9.5"
+__version__ = "0.10.0"


### PR DESCRIPTION
Some of the dependency conflicts we're seeing across CIDC packages arise from development dependencies (e.g., `pytest`) being included in cidc-schemas releases. #217 restructured development dependencies to be excluded from future schemas releases, and this PR actually releases those dependency updates.