### PR TITLE
Metadata migrations

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/cidc_schemas/migrations.py
+++ b/cidc_schemas/migrations.py
@@ -1,0 +1,86 @@
+from copy import deepcopy
+from typing import NamedTuple, Dict
+
+
+def _follow_path(d: dict, *keys):
+    for key in keys:
+        try:
+            d = d[key]
+        except (KeyError, IndexError):
+            return None
+    return d
+
+
+class MigrationResult(NamedTuple):
+    result: dict
+    file_updates: Dict[str, dict]
+
+
+class migration:
+    """
+    A `migration` contains two static methods for transforming
+    JSON trial metadata: `upgrade` and `downgrade`. Each returns takes
+    a JSON trial metadata blob as its first argument, and returns a `MigrationResult`.
+    `upgrade` and `downgrade` are inverses, i.e., for given `metadata`:
+        >>> upgraded = migration.upgrade(metadata)
+        >>> downgraded = migration.downgrade(upgraded.result)
+        >>> metadata == downgraded # should be True
+    """
+
+    @staticmethod
+    def upgrade(metadata: dict, *args, **kwargs) -> MigrationResult:
+        raise NotImplementedError
+
+    @staticmethod
+    def downgrade(metadata: dict, *args, **kwargs) -> MigrationResult:
+        raise NotImplementedError
+
+
+class v0_10_0_to_v0_10_2(migration):
+    """
+    v0.10.0 and previous wrongly treat assay_raw_ct files as XLSX.
+    This issue was fixed in v0.10.1, and this migrations module was added
+    in v0.10.2.
+    """
+
+    @staticmethod
+    def _convert(metadata: dict, to_csv: bool) -> MigrationResult:
+        """Either convert assay_raw_ct's data format from XLSX to CSV or vice versa."""
+        target_format = "CSV" if to_csv else "XLSX"
+        target_ext = ".csv" if to_csv else ".xlsx"
+        current_ext = ".xlsx" if to_csv else ".csv"
+
+        updated_metadata = deepcopy(metadata)
+
+        # Extract the olink records
+        olink_records = _follow_path(updated_metadata, "assays", "olink", "records")
+
+        # If there are no olink_records, we have no changes to make
+        if not olink_records:
+            return MigrationResult(updated_metadata, {})
+
+        # Otherwise, we need to look for every assay_raw_ct artifact,
+        # extract its GCS info, and update its data format
+        file_updates = {}
+        for record in olink_records:
+            # Extract artifact record
+            assay_raw_ct = _follow_path(record, "files", "assay_raw_ct")
+
+            # Update the data_format
+            assay_raw_ct["data_format"] = target_format
+
+            # Update the object_url and track this update in the file_updates dict
+            old_object_url = assay_raw_ct["object_url"]
+            new_object_url = old_object_url.rstrip(current_ext) + target_ext
+            assay_raw_ct["object_url"] = new_object_url
+            file_updates[old_object_url] = assay_raw_ct
+
+        return MigrationResult(updated_metadata, file_updates)
+
+    @classmethod
+    def upgrade(cls, metadata: dict, *args, **kwargs) -> MigrationResult:
+        return cls._convert(metadata, to_csv=True)
+
+    @classmethod
+    def downgrade(cls, metadata: dict, *args, **kwargs) -> MigrationResult:
+        return cls._convert(metadata, to_csv=False)

--- a/cidc_schemas/migrations.py
+++ b/cidc_schemas/migrations.py
@@ -11,6 +11,10 @@ def _follow_path(d: dict, *keys):
     return d
 
 
+class MigrationError(Exception):
+    pass
+
+
 class MigrationResult(NamedTuple):
     result: dict
     file_updates: Dict[str, dict]
@@ -65,6 +69,9 @@ class v0_10_0_to_v0_10_2(migration):
         for record in olink_records:
             # Extract artifact record
             assay_raw_ct = _follow_path(record, "files", "assay_raw_ct")
+
+            if not assay_raw_ct:
+                raise MigrationError(f"Olink record has unexpected structure: {record}")
 
             # Update the data_format
             assay_raw_ct["data_format"] = target_format

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,70 @@
+import pytest
+
+from cidc_schemas.migrations import _follow_path, v0_10_0_to_v0_10_2
+
+
+def test_follow_path():
+    """Test _follow_path utility for extracting values from dict"""
+    # Existing path
+    val = "foo"
+    d = {"a": {"b": [{}, {"c": val}]}}
+    assert _follow_path(d, "a", "b", 1, "c") == val
+
+    # Non-existing paths
+    d = {"a": {"buzz": val}}
+    assert _follow_path(d, "a", "b") is None
+    d = {"a": [val]}
+    assert _follow_path(d, 1) is None
+
+
+def test_v0_10_0_to_v0_10_2():
+
+    urls = ["tid/olink/chip_1/assay_raw_ct.xlsx", "tid/olink/chip_2/assay_raw_ct.xlsx"]
+
+    # Check that the migration treats a well-behaved CT example as expected
+    old_ct = {
+        "assays": {
+            "olink": {
+                "records": [
+                    {
+                        "files": {
+                            "assay_raw_ct": {
+                                "data_format": "XLSX",
+                                "object_url": urls[0],
+                            }
+                        }
+                    },
+                    {
+                        "files": {
+                            "assay_raw_ct": {
+                                "data_format": "XLSX",
+                                "object_url": urls[1],
+                            }
+                        }
+                    },
+                ]
+            }
+        }
+    }
+
+    res = v0_10_0_to_v0_10_2.upgrade(old_ct)
+
+    # Extract artifacts from migration result
+    get_artifact_path = lambda record_idx: _follow_path(
+        res.result, "assays", "olink", "records", record_idx, "files", "assay_raw_ct"
+    )
+
+    # Check that artifacts were successfully upgraded and
+    # that file_updates track updates as expected
+    print(res.file_updates)
+    print(res.result)
+    for i in range(2):
+        artifact = get_artifact_path(i)
+        assert artifact["data_format"] == "CSV"
+        assert artifact["object_url"].endswith(".csv")
+
+        assert urls[i] in res.file_updates
+        assert res.file_updates[urls[i]] == artifact
+
+    # Check upgrade/downgrade inverse
+    assert v0_10_0_to_v0_10_2.downgrade(res.result).result == old_ct


### PR DESCRIPTION
This PR:
* introduces a framework for managing metadata migrations between different cidc schemas versions
* creates a migration from data model v0.10.0 to data model v0.10.2 (update olink's `assay_raw_ct` artifact's data format from XLSX to CSV)