### PR TITLE
Require *either* CRC32c or MD5 has on artifacts, not just MD5

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.12.5"
+__version__ = "0.12.6"

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -865,6 +865,9 @@ def merge_artifact(
         artifact: updated artifactf
         additional_artifact_metadata: relevant metadata collected while updating artifact
     """
+    assert (
+        crc32c_hash or md5_hash
+    ), f"Either crc32c_hash or md5_hash must be provided for artifact: {object_url}"
 
     # urls are created like this in _process_property:
     file_name, uuid = object_url.split("/")[-2:]

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -845,7 +845,8 @@ def merge_artifact(
     assay_type: str,
     file_size_bytes: int,
     uploaded_timestamp: str,
-    crc32c_hash: str,
+    crc32c_hash: str = None,
+    md5_hash: str = None,
 ) -> (dict, dict, dict):
     """
     create and merge an artifact into the metadata blob
@@ -857,8 +858,8 @@ def merge_artifact(
         object_url: the gs url pointing to the object being added
         file_size_bytes: integer specifying the number of bytes in the file
         uploaded_timestamp: time stamp associated with this object
-        crc32c_hash: hash of the uploaded object, usually provided by
-                    object storage
+        md5_hash: md5 hash of the uploaded object, provided by GCS for non-composite objects
+        crc32c_hash: crc32c hash of the uploaded object, provided by GCS for all objects
     Returns:
         ct: updated clinical trial object
         artifact: updated artifactf
@@ -875,6 +876,7 @@ def merge_artifact(
         "file_name": file_name,
         "file_size_bytes": file_size_bytes,
         "crc32c_hash": crc32c_hash,
+        "md5_hash": md5_hash,
         "uploaded_timestamp": uploaded_timestamp,
     }
 

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -3,7 +3,7 @@ import json
 import os
 import copy
 import uuid
-from typing import Union, BinaryIO, Tuple, List, NamedTuple, Any
+from typing import Union, BinaryIO, Tuple, List, NamedTuple, Any, Optional
 
 import openpyxl
 import jsonschema
@@ -845,8 +845,8 @@ def merge_artifact(
     assay_type: str,
     file_size_bytes: int,
     uploaded_timestamp: str,
-    crc32c_hash: str = None,
-    md5_hash: str = None,
+    crc32c_hash: Optional[str] = None,
+    md5_hash: Optional[str] = None,
 ) -> (dict, dict, dict):
     """
     create and merge an artifact into the metadata blob

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -874,7 +874,7 @@ def merge_artifact(
         "object_url": object_url,
         "file_name": file_name,
         "file_size_bytes": file_size_bytes,
-        "md5_hash": md5_hash,
+        "crc32c_hash": md5_hash,
         "uploaded_timestamp": uploaded_timestamp,
     }
 

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -845,7 +845,7 @@ def merge_artifact(
     assay_type: str,
     file_size_bytes: int,
     uploaded_timestamp: str,
-    md5_hash: str,
+    crc32c_hash: str,
 ) -> (dict, dict, dict):
     """
     create and merge an artifact into the metadata blob
@@ -857,7 +857,7 @@ def merge_artifact(
         object_url: the gs url pointing to the object being added
         file_size_bytes: integer specifying the number of bytes in the file
         uploaded_timestamp: time stamp associated with this object
-        md5_hash: hash of the uploaded object, usually provided by
+        crc32c_hash: hash of the uploaded object, usually provided by
                     object storage
     Returns:
         ct: updated clinical trial object
@@ -874,7 +874,7 @@ def merge_artifact(
         "object_url": object_url,
         "file_name": file_name,
         "file_size_bytes": file_size_bytes,
-        "crc32c_hash": md5_hash,
+        "crc32c_hash": crc32c_hash,
         "uploaded_timestamp": uploaded_timestamp,
     }
 

--- a/cidc_schemas/schemas/artifacts/artifact_core.json
+++ b/cidc_schemas/schemas/artifacts/artifact_core.json
@@ -46,7 +46,7 @@
       "type": "string"
     },
     "crc32c_hash": {
-      "description": "CRC Hash of artifact.",
+      "description": "CRC32c Hash of artifact.",
       "type": "string"
     },
     "visible": {
@@ -90,14 +90,24 @@
   },
   "anyOf": [
     {
-      "required": [
-        "file_name",
-        "object_url",
-        "uploaded_timestamp",
-        "file_size_bytes",
-        "crc32c_hash",
-        "artifact_category",
-        "data_format"
+      "allOf": [
+        {
+          "required": [
+            "file_name",
+            "object_url",
+            "uploaded_timestamp",
+            "file_size_bytes",
+            "artifact_category",
+            "data_format"
+          ]
+        },
+        {
+          "$comment": "artifacts must have either an md5_hash or a crc32c_hash",
+          "anyOf": [
+            { "required": ["md5_hash"] },
+            { "required": ["crc32c_hash"] }
+          ]
+        }
       ]
     },
     {

--- a/cidc_schemas/schemas/artifacts/artifact_core.json
+++ b/cidc_schemas/schemas/artifacts/artifact_core.json
@@ -90,24 +90,25 @@
   },
   "anyOf": [
     {
-      "allOf": [
-        {
-          "required": [
-            "file_name",
-            "object_url",
-            "uploaded_timestamp",
-            "file_size_bytes",
-            "artifact_category",
-            "data_format"
-          ]
-        },
-        {
-          "$comment": "artifacts must have either an md5_hash or a crc32c_hash",
-          "anyOf": [
-            { "required": ["md5_hash"] },
-            { "required": ["crc32c_hash"] }
-          ]
-        }
+      "required": [
+        "file_name",
+        "object_url",
+        "uploaded_timestamp",
+        "file_size_bytes",
+        "artifact_category",
+        "data_format",
+        "md5_hash"
+      ]
+    },
+    {
+      "required": [
+        "file_name",
+        "object_url",
+        "uploaded_timestamp",
+        "file_size_bytes",
+        "artifact_category",
+        "data_format",
+        "crc32c_hash"
       ]
     },
     {

--- a/cidc_schemas/schemas/artifacts/artifact_core.json
+++ b/cidc_schemas/schemas/artifacts/artifact_core.json
@@ -42,7 +42,11 @@
       "type": "integer"
     },
     "md5_hash": {
-      "description": "MD5 Hash of artifact.",
+      "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+      "type": "string"
+    },
+    "crc32c_hash": {
+      "description": "CRC Hash of artifact.",
       "type": "string"
     },
     "visible": {
@@ -91,7 +95,7 @@
         "object_url",
         "uploaded_timestamp",
         "file_size_bytes",
-        "md5_hash",
+        "crc32c_hash",
         "artifact_category",
         "data_format"
       ]

--- a/docs/docs/artifacts.artifact_bai.html
+++ b/docs/docs/artifacts.artifact_bai.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_bam.html
+++ b/docs/docs/artifacts.artifact_bam.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_binary.html
+++ b/docs/docs/artifacts.artifact_binary.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_core.html
+++ b/docs/docs/artifacts.artifact_core.html
@@ -358,7 +358,7 @@
                 <tr>
     <td>
         
-            <span id="md5_hash">
+            <span id="crc32c_hash">
                 md5_hash
             </span>
             
@@ -547,7 +547,7 @@
                 "object_url",
                 "uploaded_timestamp",
                 "file_size_bytes",
-                "md5_hash",
+                "crc32c_hash",
                 "artifact_category",
                 "data_format"
             ]
@@ -613,7 +613,7 @@
             "description": "File size in bytes.",
             "type": "integer"
         },
-        "md5_hash": {
+        "crc32c_hash": {
             "description": "MD5 Hash of artifact.",
             "type": "string"
         },

--- a/docs/docs/artifacts.artifact_csv.html
+++ b/docs/docs/artifacts.artifact_csv.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_fastq_gz.html
+++ b/docs/docs/artifacts.artifact_fastq_gz.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_fcs.html
+++ b/docs/docs/artifacts.artifact_fcs.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_gz.html
+++ b/docs/docs/artifacts.artifact_gz.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_image.html
+++ b/docs/docs/artifacts.artifact_image.html
@@ -239,7 +239,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -305,7 +305,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_json.html
+++ b/docs/docs/artifacts.artifact_json.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_maf.html
+++ b/docs/docs/artifacts.artifact_maf.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_npx.html
+++ b/docs/docs/artifacts.artifact_npx.html
@@ -208,7 +208,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -274,7 +274,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_tbi.html
+++ b/docs/docs/artifacts.artifact_tbi.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_text.html
+++ b/docs/docs/artifacts.artifact_text.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_tsv.html
+++ b/docs/docs/artifacts.artifact_tsv.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_vcf.html
+++ b/docs/docs/artifacts.artifact_vcf.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_vcf_gz.html
+++ b/docs/docs/artifacts.artifact_vcf_gz.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_xlsx.html
+++ b/docs/docs/artifacts.artifact_xlsx.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/artifacts.artifact_zip.html
+++ b/docs/docs/artifacts.artifact_zip.html
@@ -134,7 +134,7 @@
                         "object_url",
                         "uploaded_timestamp",
                         "file_size_bytes",
-                        "md5_hash",
+                        "crc32c_hash",
                         "artifact_category",
                         "data_format"
                     ]
@@ -200,7 +200,7 @@
                     "description": "File size in bytes.",
                     "type": "integer"
                 },
-                "md5_hash": {
+                "crc32c_hash": {
                     "description": "MD5 Hash of artifact.",
                     "type": "string"
                 },

--- a/docs/docs/assays.components.available_assays.html
+++ b/docs/docs/assays.components.available_assays.html
@@ -540,7 +540,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -606,7 +606,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -669,7 +669,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -735,7 +735,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -817,7 +817,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -883,7 +883,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -945,7 +945,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1011,7 +1011,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1073,7 +1073,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1139,7 +1139,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1201,7 +1201,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1267,7 +1267,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1329,7 +1329,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1395,7 +1395,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1457,7 +1457,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1523,7 +1523,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1585,7 +1585,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1651,7 +1651,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1713,7 +1713,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1779,7 +1779,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1841,7 +1841,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1907,7 +1907,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -2212,7 +2212,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -2278,7 +2278,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -2368,7 +2368,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -2434,7 +2434,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -2524,7 +2524,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -2590,7 +2590,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -3002,7 +3002,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3068,7 +3068,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3158,7 +3158,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3224,7 +3224,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3331,7 +3331,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3397,7 +3397,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3460,7 +3460,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3526,7 +3526,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3589,7 +3589,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3655,7 +3655,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3718,7 +3718,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3784,7 +3784,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3874,7 +3874,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3940,7 +3940,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -4030,7 +4030,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -4096,7 +4096,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -4168,7 +4168,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -4234,7 +4234,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -4562,7 +4562,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -4628,7 +4628,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -4700,7 +4700,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -4766,7 +4766,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -4829,7 +4829,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -4895,7 +4895,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -4958,7 +4958,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -5024,7 +5024,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -5087,7 +5087,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -5153,7 +5153,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -5243,7 +5243,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -5309,7 +5309,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -5399,7 +5399,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -5465,7 +5465,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -5540,7 +5540,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -5606,7 +5606,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -5696,7 +5696,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -5762,7 +5762,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -5864,7 +5864,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -5930,7 +5930,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -5993,7 +5993,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -6059,7 +6059,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -6217,7 +6217,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6283,7 +6283,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6375,7 +6375,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6441,7 +6441,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6583,7 +6583,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -6649,7 +6649,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -6914,7 +6914,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -6980,7 +6980,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7047,7 +7047,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7113,7 +7113,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7180,7 +7180,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7246,7 +7246,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7381,7 +7381,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7447,7 +7447,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7514,7 +7514,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7580,7 +7580,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7647,7 +7647,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7713,7 +7713,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7963,7 +7963,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8029,7 +8029,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8096,7 +8096,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8162,7 +8162,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8229,7 +8229,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8295,7 +8295,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8415,7 +8415,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -8481,7 +8481,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -8543,7 +8543,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -8609,7 +8609,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -8671,7 +8671,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -8737,7 +8737,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -8799,7 +8799,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -8865,7 +8865,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -8927,7 +8927,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -8993,7 +8993,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9055,7 +9055,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9121,7 +9121,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9209,7 +9209,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9275,7 +9275,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9337,7 +9337,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9403,7 +9403,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9465,7 +9465,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9531,7 +9531,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9593,7 +9593,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9659,7 +9659,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9721,7 +9721,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9787,7 +9787,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9849,7 +9849,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9915,7 +9915,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9977,7 +9977,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10043,7 +10043,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10105,7 +10105,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10171,7 +10171,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10252,7 +10252,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10318,7 +10318,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10380,7 +10380,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10446,7 +10446,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },

--- a/docs/docs/assays.components.available_ngs_analyses.html
+++ b/docs/docs/assays.components.available_ngs_analyses.html
@@ -129,7 +129,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -195,7 +195,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -270,7 +270,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -336,7 +336,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -398,7 +398,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -464,7 +464,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -540,7 +540,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -606,7 +606,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -668,7 +668,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -734,7 +734,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -809,7 +809,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -875,7 +875,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -950,7 +950,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1016,7 +1016,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1078,7 +1078,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1144,7 +1144,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1206,7 +1206,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1272,7 +1272,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1334,7 +1334,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1400,7 +1400,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1482,7 +1482,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1548,7 +1548,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1610,7 +1610,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1676,7 +1676,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1738,7 +1738,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1804,7 +1804,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1866,7 +1866,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1932,7 +1932,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1994,7 +1994,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2060,7 +2060,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -2122,7 +2122,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2188,7 +2188,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -2276,7 +2276,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2342,7 +2342,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -2404,7 +2404,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2470,7 +2470,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -2532,7 +2532,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2598,7 +2598,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -2660,7 +2660,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2726,7 +2726,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -2788,7 +2788,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2854,7 +2854,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -2916,7 +2916,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -2982,7 +2982,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -3044,7 +3044,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -3110,7 +3110,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -3172,7 +3172,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -3238,7 +3238,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -3319,7 +3319,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -3385,7 +3385,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -3447,7 +3447,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -3513,7 +3513,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -3596,7 +3596,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3662,7 +3662,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3741,7 +3741,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3807,7 +3807,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3869,7 +3869,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3935,7 +3935,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3997,7 +3997,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4063,7 +4063,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -4125,7 +4125,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4191,7 +4191,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -4253,7 +4253,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4319,7 +4319,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -4381,7 +4381,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4447,7 +4447,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -4509,7 +4509,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4575,7 +4575,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -4637,7 +4637,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4703,7 +4703,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -4765,7 +4765,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4831,7 +4831,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -4893,7 +4893,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -4959,7 +4959,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5021,7 +5021,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5087,7 +5087,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5149,7 +5149,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5215,7 +5215,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5277,7 +5277,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5343,7 +5343,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5405,7 +5405,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5471,7 +5471,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5533,7 +5533,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5599,7 +5599,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5661,7 +5661,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5727,7 +5727,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5789,7 +5789,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5855,7 +5855,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -5917,7 +5917,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -5983,7 +5983,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6045,7 +6045,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6111,7 +6111,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6173,7 +6173,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6239,7 +6239,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6301,7 +6301,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6367,7 +6367,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6468,7 +6468,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6534,7 +6534,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6596,7 +6596,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6662,7 +6662,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6724,7 +6724,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6790,7 +6790,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6852,7 +6852,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6918,7 +6918,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6980,7 +6980,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7046,7 +7046,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -7108,7 +7108,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7174,7 +7174,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -7262,7 +7262,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7328,7 +7328,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -7390,7 +7390,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7456,7 +7456,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -7518,7 +7518,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7584,7 +7584,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -7646,7 +7646,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7712,7 +7712,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -7774,7 +7774,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7840,7 +7840,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -7902,7 +7902,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -7968,7 +7968,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -8030,7 +8030,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -8096,7 +8096,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -8158,7 +8158,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -8224,7 +8224,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -8305,7 +8305,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -8371,7 +8371,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -8433,7 +8433,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -8499,7 +8499,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },

--- a/docs/docs/assays.components.composite_image.html
+++ b/docs/docs/assays.components.composite_image.html
@@ -139,7 +139,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -205,7 +205,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -295,7 +295,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -361,7 +361,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.cytof.cytof_analysis.html
+++ b/docs/docs/assays.components.cytof.cytof_analysis.html
@@ -310,7 +310,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -376,7 +376,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -438,7 +438,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -504,7 +504,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -566,7 +566,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -632,7 +632,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -694,7 +694,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -760,7 +760,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -822,7 +822,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -888,7 +888,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -950,7 +950,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1016,7 +1016,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1078,7 +1078,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1144,7 +1144,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1206,7 +1206,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1272,7 +1272,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1334,7 +1334,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1400,7 +1400,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.cytof.cytof_entry.html
+++ b/docs/docs/assays.components.cytof.cytof_entry.html
@@ -713,7 +713,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -779,7 +779,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -842,7 +842,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -908,7 +908,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -990,7 +990,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1056,7 +1056,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1118,7 +1118,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1184,7 +1184,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1246,7 +1246,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1312,7 +1312,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1374,7 +1374,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1440,7 +1440,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1502,7 +1502,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1568,7 +1568,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1630,7 +1630,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1696,7 +1696,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1758,7 +1758,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1824,7 +1824,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1886,7 +1886,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1952,7 +1952,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -2014,7 +2014,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -2080,7 +2080,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },

--- a/docs/docs/assays.components.cytof.cytof_input.html
+++ b/docs/docs/assays.components.cytof.cytof_input.html
@@ -149,7 +149,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -215,7 +215,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -278,7 +278,7 @@
                                     "object_url",
                                     "uploaded_timestamp",
                                     "file_size_bytes",
-                                    "md5_hash",
+                                    "crc32c_hash",
                                     "artifact_category",
                                     "data_format"
                                 ]
@@ -344,7 +344,7 @@
                                 "description": "File size in bytes.",
                                 "type": "integer"
                             },
-                            "md5_hash": {
+                            "crc32c_hash": {
                                 "description": "MD5 Hash of artifact.",
                                 "type": "string"
                             },

--- a/docs/docs/assays.components.fastq_pair_or_bam.html
+++ b/docs/docs/assays.components.fastq_pair_or_bam.html
@@ -217,7 +217,7 @@
                                     "object_url",
                                     "uploaded_timestamp",
                                     "file_size_bytes",
-                                    "md5_hash",
+                                    "crc32c_hash",
                                     "artifact_category",
                                     "data_format"
                                 ]
@@ -283,7 +283,7 @@
                                 "description": "File size in bytes.",
                                 "type": "integer"
                             },
-                            "md5_hash": {
+                            "crc32c_hash": {
                                 "description": "MD5 Hash of artifact.",
                                 "type": "string"
                             },
@@ -350,7 +350,7 @@
                                     "object_url",
                                     "uploaded_timestamp",
                                     "file_size_bytes",
-                                    "md5_hash",
+                                    "crc32c_hash",
                                     "artifact_category",
                                     "data_format"
                                 ]
@@ -416,7 +416,7 @@
                                 "description": "File size in bytes.",
                                 "type": "integer"
                             },
-                            "md5_hash": {
+                            "crc32c_hash": {
                                 "description": "MD5 Hash of artifact.",
                                 "type": "string"
                             },
@@ -483,7 +483,7 @@
                                     "object_url",
                                     "uploaded_timestamp",
                                     "file_size_bytes",
-                                    "md5_hash",
+                                    "crc32c_hash",
                                     "artifact_category",
                                     "data_format"
                                 ]
@@ -549,7 +549,7 @@
                                 "description": "File size in bytes.",
                                 "type": "integer"
                             },
-                            "md5_hash": {
+                            "crc32c_hash": {
                                 "description": "MD5 Hash of artifact.",
                                 "type": "string"
                             },

--- a/docs/docs/assays.components.imaging.ihc_entry.html
+++ b/docs/docs/assays.components.imaging.ihc_entry.html
@@ -510,7 +510,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -576,7 +576,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -666,7 +666,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -732,7 +732,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -822,7 +822,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -888,7 +888,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },

--- a/docs/docs/assays.components.imaging.ihc_input.html
+++ b/docs/docs/assays.components.imaging.ihc_input.html
@@ -164,7 +164,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -230,7 +230,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -320,7 +320,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -386,7 +386,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -476,7 +476,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -542,7 +542,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.imaging.micsss_entry.html
+++ b/docs/docs/assays.components.imaging.micsss_entry.html
@@ -196,7 +196,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -262,7 +262,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -352,7 +352,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -418,7 +418,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -525,7 +525,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -591,7 +591,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -654,7 +654,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -720,7 +720,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -783,7 +783,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -849,7 +849,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -912,7 +912,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -978,7 +978,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1068,7 +1068,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1134,7 +1134,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1224,7 +1224,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1290,7 +1290,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1362,7 +1362,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1428,7 +1428,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },

--- a/docs/docs/assays.components.imaging.micsss_input.html
+++ b/docs/docs/assays.components.imaging.micsss_input.html
@@ -195,7 +195,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -261,7 +261,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -351,7 +351,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -417,7 +417,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -524,7 +524,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -590,7 +590,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -653,7 +653,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -719,7 +719,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -782,7 +782,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -848,7 +848,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -911,7 +911,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -977,7 +977,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -1067,7 +1067,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -1133,7 +1133,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -1223,7 +1223,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -1289,7 +1289,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -1361,7 +1361,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1427,7 +1427,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.imaging.mif_entry.html
+++ b/docs/docs/assays.components.imaging.mif_entry.html
@@ -187,7 +187,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -253,7 +253,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -325,7 +325,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -391,7 +391,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -454,7 +454,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -520,7 +520,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -583,7 +583,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -649,7 +649,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -712,7 +712,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -778,7 +778,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -868,7 +868,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -934,7 +934,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1024,7 +1024,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1090,7 +1090,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1165,7 +1165,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1231,7 +1231,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1321,7 +1321,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1387,7 +1387,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1489,7 +1489,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1555,7 +1555,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1618,7 +1618,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1684,7 +1684,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },

--- a/docs/docs/assays.components.imaging.mif_input.html
+++ b/docs/docs/assays.components.imaging.mif_input.html
@@ -204,7 +204,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -270,7 +270,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -342,7 +342,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -408,7 +408,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -471,7 +471,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -537,7 +537,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -600,7 +600,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -666,7 +666,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -729,7 +729,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -795,7 +795,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -885,7 +885,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -951,7 +951,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1041,7 +1041,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1107,7 +1107,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1182,7 +1182,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1248,7 +1248,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1338,7 +1338,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1404,7 +1404,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1506,7 +1506,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1572,7 +1572,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1635,7 +1635,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1701,7 +1701,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.mapping.html
+++ b/docs/docs/assays.components.mapping.html
@@ -237,7 +237,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -303,7 +303,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -366,7 +366,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -432,7 +432,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -495,7 +495,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -561,7 +561,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -624,7 +624,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -690,7 +690,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -780,7 +780,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -846,7 +846,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -936,7 +936,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1002,7 +1002,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.ngs_assay_record.html
+++ b/docs/docs/assays.components.ngs.ngs_assay_record.html
@@ -349,7 +349,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -415,7 +415,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -482,7 +482,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -548,7 +548,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -615,7 +615,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -681,7 +681,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },

--- a/docs/docs/assays.components.ngs.rna_expression_entry.html
+++ b/docs/docs/assays.components.ngs.rna_expression_entry.html
@@ -285,7 +285,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -351,7 +351,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -418,7 +418,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -484,7 +484,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -551,7 +551,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -617,7 +617,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -752,7 +752,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -818,7 +818,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -885,7 +885,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -951,7 +951,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1018,7 +1018,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1084,7 +1084,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },

--- a/docs/docs/assays.components.ngs.rna_input.html
+++ b/docs/docs/assays.components.ngs.rna_input.html
@@ -129,7 +129,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -195,7 +195,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -262,7 +262,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -328,7 +328,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },
@@ -395,7 +395,7 @@
                                             "object_url",
                                             "uploaded_timestamp",
                                             "file_size_bytes",
-                                            "md5_hash",
+                                            "crc32c_hash",
                                             "artifact_category",
                                             "data_format"
                                         ]
@@ -461,7 +461,7 @@
                                         "description": "File size in bytes.",
                                         "type": "integer"
                                     },
-                                    "md5_hash": {
+                                    "crc32c_hash": {
                                         "description": "MD5 Hash of artifact.",
                                         "type": "string"
                                     },

--- a/docs/docs/assays.components.ngs.wes.alignment.html
+++ b/docs/docs/assays.components.ngs.wes.alignment.html
@@ -247,7 +247,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -313,7 +313,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -375,7 +375,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -441,7 +441,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -503,7 +503,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -569,7 +569,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -631,7 +631,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -697,7 +697,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -759,7 +759,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -825,7 +825,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -887,7 +887,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -953,7 +953,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.clonality.html
+++ b/docs/docs/assays.components.ngs.wes.clonality.html
@@ -112,7 +112,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -178,7 +178,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.copynumber.html
+++ b/docs/docs/assays.components.ngs.wes.copynumber.html
@@ -139,7 +139,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -205,7 +205,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -267,7 +267,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -333,7 +333,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.corealignments.html
+++ b/docs/docs/assays.components.ngs.wes.corealignments.html
@@ -137,7 +137,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -203,7 +203,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -265,7 +265,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -331,7 +331,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.coverage_metrics.html
+++ b/docs/docs/assays.components.ngs.wes.coverage_metrics.html
@@ -299,7 +299,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -365,7 +365,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -427,7 +427,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -493,7 +493,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -555,7 +555,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -621,7 +621,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -683,7 +683,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -749,7 +749,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -811,7 +811,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -877,7 +877,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -939,7 +939,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1005,7 +1005,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1067,7 +1067,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1133,7 +1133,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1195,7 +1195,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1261,7 +1261,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.germline.html
+++ b/docs/docs/assays.components.ngs.wes.germline.html
@@ -112,7 +112,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -178,7 +178,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.neoantigen.html
+++ b/docs/docs/assays.components.ngs.wes.neoantigen.html
@@ -189,7 +189,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -255,7 +255,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -317,7 +317,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -383,7 +383,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -445,7 +445,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -511,7 +511,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -573,7 +573,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -639,7 +639,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.optitype.html
+++ b/docs/docs/assays.components.ngs.wes.optitype.html
@@ -139,7 +139,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -205,7 +205,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -267,7 +267,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -333,7 +333,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.purity.html
+++ b/docs/docs/assays.components.ngs.wes.purity.html
@@ -112,7 +112,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -178,7 +178,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.somatic.html
+++ b/docs/docs/assays.components.ngs.wes.somatic.html
@@ -652,7 +652,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -718,7 +718,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -780,7 +780,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -846,7 +846,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -908,7 +908,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -974,7 +974,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1036,7 +1036,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1102,7 +1102,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1164,7 +1164,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1230,7 +1230,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1292,7 +1292,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1358,7 +1358,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1420,7 +1420,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1486,7 +1486,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1548,7 +1548,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1614,7 +1614,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1676,7 +1676,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1742,7 +1742,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1804,7 +1804,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1870,7 +1870,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -1932,7 +1932,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -1998,7 +1998,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2060,7 +2060,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -2126,7 +2126,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2188,7 +2188,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -2254,7 +2254,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2316,7 +2316,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -2382,7 +2382,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2444,7 +2444,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -2510,7 +2510,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2572,7 +2572,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -2638,7 +2638,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2700,7 +2700,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -2766,7 +2766,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2828,7 +2828,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -2894,7 +2894,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -2956,7 +2956,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -3022,7 +3022,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -3084,7 +3084,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -3150,7 +3150,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -3212,7 +3212,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -3278,7 +3278,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.ngs.wes.wes_analysis.html
+++ b/docs/docs/assays.components.ngs.wes.wes_analysis.html
@@ -137,7 +137,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -203,7 +203,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -278,7 +278,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -344,7 +344,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -406,7 +406,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -472,7 +472,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -548,7 +548,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -614,7 +614,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -676,7 +676,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -742,7 +742,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -817,7 +817,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -883,7 +883,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -958,7 +958,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1024,7 +1024,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1086,7 +1086,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1152,7 +1152,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1214,7 +1214,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1280,7 +1280,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1342,7 +1342,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1408,7 +1408,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1490,7 +1490,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1556,7 +1556,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1618,7 +1618,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1684,7 +1684,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1746,7 +1746,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1812,7 +1812,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1874,7 +1874,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1940,7 +1940,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2002,7 +2002,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2068,7 +2068,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2130,7 +2130,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2196,7 +2196,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2284,7 +2284,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2350,7 +2350,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2412,7 +2412,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2478,7 +2478,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2540,7 +2540,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2606,7 +2606,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2668,7 +2668,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2734,7 +2734,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2796,7 +2796,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2862,7 +2862,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2924,7 +2924,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2990,7 +2990,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3052,7 +3052,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3118,7 +3118,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3180,7 +3180,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3246,7 +3246,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3327,7 +3327,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3393,7 +3393,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3455,7 +3455,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3521,7 +3521,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -3604,7 +3604,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -3670,7 +3670,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -3749,7 +3749,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -3815,7 +3815,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -3877,7 +3877,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -3943,7 +3943,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4005,7 +4005,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4071,7 +4071,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4133,7 +4133,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4199,7 +4199,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4261,7 +4261,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4327,7 +4327,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4389,7 +4389,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4455,7 +4455,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4517,7 +4517,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4583,7 +4583,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4645,7 +4645,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4711,7 +4711,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4773,7 +4773,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4839,7 +4839,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -4901,7 +4901,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -4967,7 +4967,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5029,7 +5029,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5095,7 +5095,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5157,7 +5157,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5223,7 +5223,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5285,7 +5285,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5351,7 +5351,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5413,7 +5413,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5479,7 +5479,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5541,7 +5541,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5607,7 +5607,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5669,7 +5669,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5735,7 +5735,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5797,7 +5797,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5863,7 +5863,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -5925,7 +5925,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -5991,7 +5991,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -6053,7 +6053,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -6119,7 +6119,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -6181,7 +6181,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -6247,7 +6247,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -6309,7 +6309,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -6375,7 +6375,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -6476,7 +6476,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6542,7 +6542,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6604,7 +6604,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6670,7 +6670,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6732,7 +6732,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6798,7 +6798,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6860,7 +6860,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -6926,7 +6926,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -6988,7 +6988,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7054,7 +7054,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -7116,7 +7116,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7182,7 +7182,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -7270,7 +7270,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7336,7 +7336,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -7398,7 +7398,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7464,7 +7464,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -7526,7 +7526,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7592,7 +7592,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -7654,7 +7654,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7720,7 +7720,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -7782,7 +7782,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7848,7 +7848,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -7910,7 +7910,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -7976,7 +7976,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -8038,7 +8038,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -8104,7 +8104,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -8166,7 +8166,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -8232,7 +8232,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -8313,7 +8313,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -8379,7 +8379,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -8441,7 +8441,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -8507,7 +8507,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },

--- a/docs/docs/assays.components.ngs.wes.wes_entry.html
+++ b/docs/docs/assays.components.ngs.wes.wes_entry.html
@@ -297,7 +297,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -363,7 +363,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -430,7 +430,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -496,7 +496,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -563,7 +563,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -629,7 +629,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -749,7 +749,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -815,7 +815,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -877,7 +877,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -943,7 +943,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1005,7 +1005,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1071,7 +1071,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1133,7 +1133,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1199,7 +1199,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1261,7 +1261,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1327,7 +1327,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1389,7 +1389,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1455,7 +1455,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1543,7 +1543,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1609,7 +1609,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1671,7 +1671,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1737,7 +1737,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1799,7 +1799,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1865,7 +1865,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1927,7 +1927,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1993,7 +1993,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2055,7 +2055,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2121,7 +2121,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2183,7 +2183,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2249,7 +2249,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2311,7 +2311,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2377,7 +2377,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2439,7 +2439,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2505,7 +2505,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2586,7 +2586,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2652,7 +2652,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2714,7 +2714,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2780,7 +2780,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },

--- a/docs/docs/assays.components.ngs.wes.wes_pair_analysis.html
+++ b/docs/docs/assays.components.ngs.wes.wes_pair_analysis.html
@@ -357,7 +357,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -423,7 +423,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -498,7 +498,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -564,7 +564,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -626,7 +626,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -692,7 +692,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -768,7 +768,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -834,7 +834,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -896,7 +896,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -962,7 +962,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1037,7 +1037,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1103,7 +1103,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1178,7 +1178,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1244,7 +1244,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1306,7 +1306,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1372,7 +1372,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1434,7 +1434,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1500,7 +1500,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1562,7 +1562,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1628,7 +1628,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1710,7 +1710,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1776,7 +1776,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1838,7 +1838,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -1904,7 +1904,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -1966,7 +1966,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2032,7 +2032,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2094,7 +2094,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2160,7 +2160,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2222,7 +2222,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2288,7 +2288,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2350,7 +2350,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2416,7 +2416,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2504,7 +2504,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2570,7 +2570,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2632,7 +2632,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2698,7 +2698,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2760,7 +2760,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2826,7 +2826,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -2888,7 +2888,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -2954,7 +2954,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -3016,7 +3016,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -3082,7 +3082,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -3144,7 +3144,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -3210,7 +3210,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -3272,7 +3272,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -3338,7 +3338,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -3400,7 +3400,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -3466,7 +3466,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -3547,7 +3547,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -3613,7 +3613,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -3675,7 +3675,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -3741,7 +3741,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -3824,7 +3824,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -3890,7 +3890,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -3969,7 +3969,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4035,7 +4035,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4097,7 +4097,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4163,7 +4163,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4225,7 +4225,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4291,7 +4291,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4353,7 +4353,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4419,7 +4419,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4481,7 +4481,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4547,7 +4547,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4609,7 +4609,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4675,7 +4675,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4737,7 +4737,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4803,7 +4803,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4865,7 +4865,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -4931,7 +4931,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -4993,7 +4993,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5059,7 +5059,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -5121,7 +5121,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5187,7 +5187,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -5249,7 +5249,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5315,7 +5315,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -5377,7 +5377,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5443,7 +5443,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -5505,7 +5505,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5571,7 +5571,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -5633,7 +5633,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5699,7 +5699,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -5761,7 +5761,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5827,7 +5827,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -5889,7 +5889,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -5955,7 +5955,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -6017,7 +6017,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -6083,7 +6083,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -6145,7 +6145,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -6211,7 +6211,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -6273,7 +6273,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -6339,7 +6339,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -6401,7 +6401,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -6467,7 +6467,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -6529,7 +6529,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -6595,7 +6595,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -6696,7 +6696,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -6762,7 +6762,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -6824,7 +6824,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -6890,7 +6890,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -6952,7 +6952,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7018,7 +7018,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -7080,7 +7080,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7146,7 +7146,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -7208,7 +7208,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7274,7 +7274,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -7336,7 +7336,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7402,7 +7402,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -7490,7 +7490,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7556,7 +7556,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -7618,7 +7618,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7684,7 +7684,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -7746,7 +7746,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7812,7 +7812,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -7874,7 +7874,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -7940,7 +7940,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -8002,7 +8002,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -8068,7 +8068,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -8130,7 +8130,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -8196,7 +8196,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -8258,7 +8258,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -8324,7 +8324,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -8386,7 +8386,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -8452,7 +8452,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -8533,7 +8533,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -8599,7 +8599,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },
@@ -8661,7 +8661,7 @@
                                                 "object_url",
                                                 "uploaded_timestamp",
                                                 "file_size_bytes",
-                                                "md5_hash",
+                                                "crc32c_hash",
                                                 "artifact_category",
                                                 "data_format"
                                             ]
@@ -8727,7 +8727,7 @@
                                             "description": "File size in bytes.",
                                             "type": "integer"
                                         },
-                                        "md5_hash": {
+                                        "crc32c_hash": {
                                             "description": "MD5 Hash of artifact.",
                                             "type": "string"
                                         },

--- a/docs/docs/assays.components.ngs.wes.wes_sample_analysis.html
+++ b/docs/docs/assays.components.ngs.wes.wes_sample_analysis.html
@@ -193,7 +193,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -259,7 +259,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -321,7 +321,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -387,7 +387,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -449,7 +449,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -515,7 +515,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -577,7 +577,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -643,7 +643,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -705,7 +705,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -771,7 +771,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -833,7 +833,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -899,7 +899,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -987,7 +987,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1053,7 +1053,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1115,7 +1115,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1181,7 +1181,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1243,7 +1243,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1309,7 +1309,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1371,7 +1371,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1437,7 +1437,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1499,7 +1499,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1565,7 +1565,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1627,7 +1627,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1693,7 +1693,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1755,7 +1755,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1821,7 +1821,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -1883,7 +1883,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -1949,7 +1949,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -2030,7 +2030,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -2096,7 +2096,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -2158,7 +2158,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -2224,7 +2224,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },

--- a/docs/docs/assays.components.olink.olink_combined.html
+++ b/docs/docs/assays.components.olink.olink_combined.html
@@ -154,7 +154,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -220,7 +220,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.components.olink.olink_entry.html
+++ b/docs/docs/assays.components.olink.olink_entry.html
@@ -584,7 +584,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -650,7 +650,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },
@@ -742,7 +742,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -808,7 +808,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },

--- a/docs/docs/assays.components.olink.olink_input.html
+++ b/docs/docs/assays.components.olink.olink_input.html
@@ -139,7 +139,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -205,7 +205,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },
@@ -297,7 +297,7 @@
                                 "object_url",
                                 "uploaded_timestamp",
                                 "file_size_bytes",
-                                "md5_hash",
+                                "crc32c_hash",
                                 "artifact_category",
                                 "data_format"
                             ]
@@ -363,7 +363,7 @@
                             "description": "File size in bytes.",
                             "type": "integer"
                         },
-                        "md5_hash": {
+                        "crc32c_hash": {
                             "description": "MD5 Hash of artifact.",
                             "type": "string"
                         },

--- a/docs/docs/assays.cytof_assay.html
+++ b/docs/docs/assays.cytof_assay.html
@@ -514,7 +514,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -580,7 +580,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -643,7 +643,7 @@
                                                         "object_url",
                                                         "uploaded_timestamp",
                                                         "file_size_bytes",
-                                                        "md5_hash",
+                                                        "crc32c_hash",
                                                         "artifact_category",
                                                         "data_format"
                                                     ]
@@ -709,7 +709,7 @@
                                                     "description": "File size in bytes.",
                                                     "type": "integer"
                                                 },
-                                                "md5_hash": {
+                                                "crc32c_hash": {
                                                     "description": "MD5 Hash of artifact.",
                                                     "type": "string"
                                                 },
@@ -791,7 +791,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -857,7 +857,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -919,7 +919,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -985,7 +985,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1047,7 +1047,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1113,7 +1113,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1175,7 +1175,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1241,7 +1241,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1303,7 +1303,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1369,7 +1369,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1431,7 +1431,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1497,7 +1497,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1559,7 +1559,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1625,7 +1625,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1687,7 +1687,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1753,7 +1753,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1815,7 +1815,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1881,7 +1881,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },

--- a/docs/docs/assays.ihc_assay.html
+++ b/docs/docs/assays.ihc_assay.html
@@ -406,7 +406,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -472,7 +472,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -562,7 +562,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -628,7 +628,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -718,7 +718,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -784,7 +784,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },

--- a/docs/docs/assays.micsss_assay.html
+++ b/docs/docs/assays.micsss_assay.html
@@ -468,7 +468,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -534,7 +534,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -624,7 +624,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -690,7 +690,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -797,7 +797,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -863,7 +863,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -926,7 +926,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -992,7 +992,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1055,7 +1055,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1121,7 +1121,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1184,7 +1184,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1250,7 +1250,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1340,7 +1340,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1406,7 +1406,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1496,7 +1496,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1562,7 +1562,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1634,7 +1634,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1700,7 +1700,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },

--- a/docs/docs/assays.mif_assay.html
+++ b/docs/docs/assays.mif_assay.html
@@ -428,7 +428,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -494,7 +494,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -566,7 +566,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -632,7 +632,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -695,7 +695,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -761,7 +761,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -824,7 +824,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -890,7 +890,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -953,7 +953,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -1019,7 +1019,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -1109,7 +1109,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -1175,7 +1175,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -1265,7 +1265,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -1331,7 +1331,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -1406,7 +1406,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -1472,7 +1472,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -1562,7 +1562,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -1628,7 +1628,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -1730,7 +1730,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1796,7 +1796,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -1859,7 +1859,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -1925,7 +1925,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },

--- a/docs/docs/assays.olink_assay.html
+++ b/docs/docs/assays.olink_assay.html
@@ -251,7 +251,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -317,7 +317,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -409,7 +409,7 @@
                                                     "object_url",
                                                     "uploaded_timestamp",
                                                     "file_size_bytes",
-                                                    "md5_hash",
+                                                    "crc32c_hash",
                                                     "artifact_category",
                                                     "data_format"
                                                 ]
@@ -475,7 +475,7 @@
                                                 "description": "File size in bytes.",
                                                 "type": "integer"
                                             },
-                                            "md5_hash": {
+                                            "crc32c_hash": {
                                                 "description": "MD5 Hash of artifact.",
                                                 "type": "string"
                                             },
@@ -617,7 +617,7 @@
                                         "object_url",
                                         "uploaded_timestamp",
                                         "file_size_bytes",
-                                        "md5_hash",
+                                        "crc32c_hash",
                                         "artifact_category",
                                         "data_format"
                                     ]
@@ -683,7 +683,7 @@
                                     "description": "File size in bytes.",
                                     "type": "integer"
                                 },
-                                "md5_hash": {
+                                "crc32c_hash": {
                                     "description": "MD5 Hash of artifact.",
                                     "type": "string"
                                 },

--- a/docs/docs/assays.rna_expression_assay.html
+++ b/docs/docs/assays.rna_expression_assay.html
@@ -500,7 +500,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -566,7 +566,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -633,7 +633,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -699,7 +699,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -766,7 +766,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -832,7 +832,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -967,7 +967,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1033,7 +1033,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1100,7 +1100,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1166,7 +1166,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -1233,7 +1233,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -1299,7 +1299,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },

--- a/docs/docs/assays.wes_assay.html
+++ b/docs/docs/assays.wes_assay.html
@@ -520,7 +520,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -586,7 +586,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -653,7 +653,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -719,7 +719,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -786,7 +786,7 @@
                                                                 "object_url",
                                                                 "uploaded_timestamp",
                                                                 "file_size_bytes",
-                                                                "md5_hash",
+                                                                "crc32c_hash",
                                                                 "artifact_category",
                                                                 "data_format"
                                                             ]
@@ -852,7 +852,7 @@
                                                             "description": "File size in bytes.",
                                                             "type": "integer"
                                                         },
-                                                        "md5_hash": {
+                                                        "crc32c_hash": {
                                                             "description": "MD5 Hash of artifact.",
                                                             "type": "string"
                                                         },
@@ -972,7 +972,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1038,7 +1038,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1100,7 +1100,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1166,7 +1166,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1228,7 +1228,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1294,7 +1294,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1356,7 +1356,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1422,7 +1422,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1484,7 +1484,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1550,7 +1550,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1612,7 +1612,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1678,7 +1678,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1766,7 +1766,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1832,7 +1832,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -1894,7 +1894,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -1960,7 +1960,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2022,7 +2022,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2088,7 +2088,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2150,7 +2150,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2216,7 +2216,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2278,7 +2278,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2344,7 +2344,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2406,7 +2406,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2472,7 +2472,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2534,7 +2534,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2600,7 +2600,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2662,7 +2662,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2728,7 +2728,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2809,7 +2809,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -2875,7 +2875,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },
@@ -2937,7 +2937,7 @@
                                                             "object_url",
                                                             "uploaded_timestamp",
                                                             "file_size_bytes",
-                                                            "md5_hash",
+                                                            "crc32c_hash",
                                                             "artifact_category",
                                                             "data_format"
                                                         ]
@@ -3003,7 +3003,7 @@
                                                         "description": "File size in bytes.",
                                                         "type": "integer"
                                                     },
-                                                    "md5_hash": {
+                                                    "crc32c_hash": {
                                                         "description": "MD5 Hash of artifact.",
                                                         "type": "string"
                                                     },

--- a/docs/docs/clinical_trial.html
+++ b/docs/docs/clinical_trial.html
@@ -555,7 +555,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -621,7 +621,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -696,7 +696,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -762,7 +762,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -824,7 +824,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -890,7 +890,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -966,7 +966,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1032,7 +1032,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1094,7 +1094,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1160,7 +1160,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1235,7 +1235,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1301,7 +1301,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1376,7 +1376,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1442,7 +1442,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1504,7 +1504,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1570,7 +1570,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1632,7 +1632,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1698,7 +1698,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1760,7 +1760,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -1826,7 +1826,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -1908,7 +1908,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -1974,7 +1974,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2036,7 +2036,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -2102,7 +2102,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2164,7 +2164,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -2230,7 +2230,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2292,7 +2292,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -2358,7 +2358,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2420,7 +2420,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -2486,7 +2486,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2548,7 +2548,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -2614,7 +2614,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2702,7 +2702,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -2768,7 +2768,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2830,7 +2830,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -2896,7 +2896,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -2958,7 +2958,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3024,7 +3024,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3086,7 +3086,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3152,7 +3152,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3214,7 +3214,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3280,7 +3280,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3342,7 +3342,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3408,7 +3408,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3470,7 +3470,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3536,7 +3536,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3598,7 +3598,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3664,7 +3664,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3745,7 +3745,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3811,7 +3811,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -3873,7 +3873,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -3939,7 +3939,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -4022,7 +4022,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -4088,7 +4088,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -4167,7 +4167,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -4233,7 +4233,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -4295,7 +4295,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -4361,7 +4361,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -4423,7 +4423,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -4489,7 +4489,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -4551,7 +4551,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -4617,7 +4617,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -4679,7 +4679,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -4745,7 +4745,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -4807,7 +4807,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -4873,7 +4873,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -4935,7 +4935,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5001,7 +5001,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5063,7 +5063,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5129,7 +5129,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5191,7 +5191,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5257,7 +5257,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5319,7 +5319,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5385,7 +5385,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5447,7 +5447,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5513,7 +5513,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5575,7 +5575,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5641,7 +5641,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5703,7 +5703,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5769,7 +5769,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5831,7 +5831,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -5897,7 +5897,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -5959,7 +5959,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6025,7 +6025,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6087,7 +6087,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6153,7 +6153,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6215,7 +6215,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6281,7 +6281,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6343,7 +6343,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6409,7 +6409,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6471,7 +6471,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6537,7 +6537,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6599,7 +6599,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6665,7 +6665,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6727,7 +6727,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -6793,7 +6793,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -6894,7 +6894,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -6960,7 +6960,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7022,7 +7022,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7088,7 +7088,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7150,7 +7150,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7216,7 +7216,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7278,7 +7278,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7344,7 +7344,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7406,7 +7406,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7472,7 +7472,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7534,7 +7534,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7600,7 +7600,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7688,7 +7688,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7754,7 +7754,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7816,7 +7816,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -7882,7 +7882,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -7944,7 +7944,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8010,7 +8010,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8072,7 +8072,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8138,7 +8138,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8200,7 +8200,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8266,7 +8266,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8328,7 +8328,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8394,7 +8394,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8456,7 +8456,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8522,7 +8522,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8584,7 +8584,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8650,7 +8650,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8731,7 +8731,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8797,7 +8797,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -8859,7 +8859,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -8925,7 +8925,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -9228,7 +9228,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9294,7 +9294,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9357,7 +9357,7 @@
                                                                             "object_url",
                                                                             "uploaded_timestamp",
                                                                             "file_size_bytes",
-                                                                            "md5_hash",
+                                                                            "crc32c_hash",
                                                                             "artifact_category",
                                                                             "data_format"
                                                                         ]
@@ -9423,7 +9423,7 @@
                                                                         "description": "File size in bytes.",
                                                                         "type": "integer"
                                                                     },
-                                                                    "md5_hash": {
+                                                                    "crc32c_hash": {
                                                                         "description": "MD5 Hash of artifact.",
                                                                         "type": "string"
                                                                     },
@@ -9505,7 +9505,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9571,7 +9571,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9633,7 +9633,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9699,7 +9699,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9761,7 +9761,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9827,7 +9827,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -9889,7 +9889,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -9955,7 +9955,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10017,7 +10017,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10083,7 +10083,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10145,7 +10145,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10211,7 +10211,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10273,7 +10273,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10339,7 +10339,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10401,7 +10401,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10467,7 +10467,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10529,7 +10529,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10595,7 +10595,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -10900,7 +10900,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -10966,7 +10966,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -11056,7 +11056,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -11122,7 +11122,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -11212,7 +11212,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -11278,7 +11278,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -11690,7 +11690,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -11756,7 +11756,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -11846,7 +11846,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -11912,7 +11912,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -12019,7 +12019,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -12085,7 +12085,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -12148,7 +12148,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -12214,7 +12214,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -12277,7 +12277,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -12343,7 +12343,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -12406,7 +12406,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -12472,7 +12472,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -12562,7 +12562,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -12628,7 +12628,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -12718,7 +12718,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -12784,7 +12784,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -12856,7 +12856,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -12922,7 +12922,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -13250,7 +13250,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -13316,7 +13316,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -13388,7 +13388,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -13454,7 +13454,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -13517,7 +13517,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -13583,7 +13583,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -13646,7 +13646,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -13712,7 +13712,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -13775,7 +13775,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -13841,7 +13841,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -13931,7 +13931,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -13997,7 +13997,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -14087,7 +14087,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -14153,7 +14153,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -14228,7 +14228,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -14294,7 +14294,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -14384,7 +14384,7 @@
                                                                                             "object_url",
                                                                                             "uploaded_timestamp",
                                                                                             "file_size_bytes",
-                                                                                            "md5_hash",
+                                                                                            "crc32c_hash",
                                                                                             "artifact_category",
                                                                                             "data_format"
                                                                                         ]
@@ -14450,7 +14450,7 @@
                                                                                         "description": "File size in bytes.",
                                                                                         "type": "integer"
                                                                                     },
-                                                                                    "md5_hash": {
+                                                                                    "crc32c_hash": {
                                                                                         "description": "MD5 Hash of artifact.",
                                                                                         "type": "string"
                                                                                     },
@@ -14552,7 +14552,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -14618,7 +14618,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -14681,7 +14681,7 @@
                                                                         "object_url",
                                                                         "uploaded_timestamp",
                                                                         "file_size_bytes",
-                                                                        "md5_hash",
+                                                                        "crc32c_hash",
                                                                         "artifact_category",
                                                                         "data_format"
                                                                     ]
@@ -14747,7 +14747,7 @@
                                                                     "description": "File size in bytes.",
                                                                     "type": "integer"
                                                                 },
-                                                                "md5_hash": {
+                                                                "crc32c_hash": {
                                                                     "description": "MD5 Hash of artifact.",
                                                                     "type": "string"
                                                                 },
@@ -14905,7 +14905,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -14971,7 +14971,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -15063,7 +15063,7 @@
                                                                     "object_url",
                                                                     "uploaded_timestamp",
                                                                     "file_size_bytes",
-                                                                    "md5_hash",
+                                                                    "crc32c_hash",
                                                                     "artifact_category",
                                                                     "data_format"
                                                                 ]
@@ -15129,7 +15129,7 @@
                                                                 "description": "File size in bytes.",
                                                                 "type": "integer"
                                                             },
-                                                            "md5_hash": {
+                                                            "crc32c_hash": {
                                                                 "description": "MD5 Hash of artifact.",
                                                                 "type": "string"
                                                             },
@@ -15271,7 +15271,7 @@
                                                         "object_url",
                                                         "uploaded_timestamp",
                                                         "file_size_bytes",
-                                                        "md5_hash",
+                                                        "crc32c_hash",
                                                         "artifact_category",
                                                         "data_format"
                                                     ]
@@ -15337,7 +15337,7 @@
                                                     "description": "File size in bytes.",
                                                     "type": "integer"
                                                 },
-                                                "md5_hash": {
+                                                "crc32c_hash": {
                                                     "description": "MD5 Hash of artifact.",
                                                     "type": "string"
                                                 },
@@ -15602,7 +15602,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -15668,7 +15668,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -15735,7 +15735,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -15801,7 +15801,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -15868,7 +15868,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -15934,7 +15934,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -16069,7 +16069,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -16135,7 +16135,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -16202,7 +16202,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -16268,7 +16268,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -16335,7 +16335,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -16401,7 +16401,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -16651,7 +16651,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -16717,7 +16717,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -16784,7 +16784,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -16850,7 +16850,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -16917,7 +16917,7 @@
                                                                                     "object_url",
                                                                                     "uploaded_timestamp",
                                                                                     "file_size_bytes",
-                                                                                    "md5_hash",
+                                                                                    "crc32c_hash",
                                                                                     "artifact_category",
                                                                                     "data_format"
                                                                                 ]
@@ -16983,7 +16983,7 @@
                                                                                 "description": "File size in bytes.",
                                                                                 "type": "integer"
                                                                             },
-                                                                            "md5_hash": {
+                                                                            "crc32c_hash": {
                                                                                 "description": "MD5 Hash of artifact.",
                                                                                 "type": "string"
                                                                             },
@@ -17103,7 +17103,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -17169,7 +17169,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -17231,7 +17231,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -17297,7 +17297,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -17359,7 +17359,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -17425,7 +17425,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -17487,7 +17487,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -17553,7 +17553,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -17615,7 +17615,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -17681,7 +17681,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -17743,7 +17743,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -17809,7 +17809,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -17897,7 +17897,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -17963,7 +17963,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18025,7 +18025,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -18091,7 +18091,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18153,7 +18153,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -18219,7 +18219,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18281,7 +18281,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -18347,7 +18347,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18409,7 +18409,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -18475,7 +18475,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18537,7 +18537,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -18603,7 +18603,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18665,7 +18665,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -18731,7 +18731,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18793,7 +18793,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -18859,7 +18859,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -18940,7 +18940,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -19006,7 +19006,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },
@@ -19068,7 +19068,7 @@
                                                                                 "object_url",
                                                                                 "uploaded_timestamp",
                                                                                 "file_size_bytes",
-                                                                                "md5_hash",
+                                                                                "crc32c_hash",
                                                                                 "artifact_category",
                                                                                 "data_format"
                                                                             ]
@@ -19134,7 +19134,7 @@
                                                                             "description": "File size in bytes.",
                                                                             "type": "integer"
                                                                         },
-                                                                        "md5_hash": {
+                                                                        "crc32c_hash": {
                                                                             "description": "MD5 Hash of artifact.",
                                                                             "type": "string"
                                                                         },

--- a/tests/data/clinicaltrial_examples/CT_1.json
+++ b/tests/data/clinicaltrial_examples/CT_1.json
@@ -115,7 +115,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "crc32c_hash" :            "...",
+                            "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :           "NPX",
                             "number_of_samples":   3,
@@ -126,7 +126,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "crc32c_hash" :            "...",
+                            "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :         "CSV"
                         }
@@ -143,7 +143,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "crc32c_hash" :            "...",
+                            "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :           "NPX",
                             "number_of_samples":   3,
@@ -154,7 +154,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "crc32c_hash" :            "...",
+                            "md5_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :         "CSV"
                         }
@@ -182,7 +182,7 @@
                                     "object_url" :          "...",
                                     "uploaded_timestamp" :  "...",
                                     "file_size_bytes" :     0,
-                                    "crc32c_hash" :            "...",
+                                    "md5_hash" :            "...",
                                     "artifact_category" :   "Assay Artifact from CIMAC",
                                     "data_format":          "FASTQ.GZ"
                             }],
@@ -191,7 +191,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format":          "FASTQ.GZ"
                             }]
@@ -207,7 +207,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "BAM"
                             }]
@@ -234,7 +234,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -243,7 +243,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -259,7 +259,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -268,7 +268,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]

--- a/tests/data/clinicaltrial_examples/CT_1.json
+++ b/tests/data/clinicaltrial_examples/CT_1.json
@@ -115,7 +115,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
+                            "crc32c_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :           "NPX",
                             "number_of_samples":   3,
@@ -126,7 +126,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
+                            "crc32c_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :         "CSV"
                         }
@@ -143,7 +143,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
+                            "crc32c_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :           "NPX",
                             "number_of_samples":   3,
@@ -154,7 +154,7 @@
                             "object_url" :          "...",
                             "uploaded_timestamp" :  "...",
                             "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
+                            "crc32c_hash" :            "...",
                             "artifact_category" :   "Assay Artifact from CIMAC",
                             "data_format" :         "CSV"
                         }
@@ -182,7 +182,7 @@
                                     "object_url" :          "...",
                                     "uploaded_timestamp" :  "...",
                                     "file_size_bytes" :     0,
-                                    "md5_hash" :            "...",
+                                    "crc32c_hash" :            "...",
                                     "artifact_category" :   "Assay Artifact from CIMAC",
                                     "data_format":          "FASTQ.GZ"
                             }],
@@ -191,7 +191,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format":          "FASTQ.GZ"
                             }]
@@ -207,7 +207,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "BAM"
                             }]
@@ -234,7 +234,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -243,7 +243,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -259,7 +259,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -268,7 +268,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]

--- a/tests/data/clinicaltrial_examples/CT_1PA_multiWES.json
+++ b/tests/data/clinicaltrial_examples/CT_1PA_multiWES.json
@@ -93,7 +93,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -102,7 +102,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -118,7 +118,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -127,7 +127,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -154,7 +154,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -163,7 +163,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -179,7 +179,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -188,7 +188,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "crc32c_hash" :            "...",
+                                "md5_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]

--- a/tests/data/clinicaltrial_examples/CT_1PA_multiWES.json
+++ b/tests/data/clinicaltrial_examples/CT_1PA_multiWES.json
@@ -93,7 +93,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -102,7 +102,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -118,7 +118,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -127,7 +127,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -154,7 +154,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -163,7 +163,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]
@@ -179,7 +179,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }],
@@ -188,7 +188,7 @@
                                 "object_url" :          "...",
                                 "uploaded_timestamp" :  "...",
                                 "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
+                                "crc32c_hash" :            "...",
                                 "artifact_category" :   "Assay Artifact from CIMAC",
                                 "data_format" :           "FASTQ.GZ"
                             }]

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -19,7 +19,7 @@ BASE_OBJ = {
     "file_name": "dummy.txt",
     "file_size_bytes": 1,
     "data_format": "FASTA",
-    "md5_hash": "dummy",
+    "crc32c_hash": "dummy",
     "uploaded_timestamp": "dummy",
     "uuid": "dummy",
     "visible": True,
@@ -48,7 +48,7 @@ def test_upload_placeholder_oneOf_required():
               "object_url",
               "uploaded_timestamp",
               "file_size_bytes",
-              "md5_hash",
+              "crc32c_hash",
               "artifact_category"
             ]
           },
@@ -71,7 +71,7 @@ def test_upload_placeholder_oneOf_required():
     del obj["object_url"]
     del obj["uploaded_timestamp"]
     del obj["file_size_bytes"]
-    del obj["md5_hash"]
+    del obj["crc32c_hash"]
     del obj["artifact_category"]
     with pytest.raises(jsonschema.ValidationError):
         at_validator.validate(obj)
@@ -93,7 +93,7 @@ def test_text():
     at_validator.validate(obj)
 
     # assert we can fail it.
-    del obj["md5_hash"]
+    del obj["crc32c_hash"]
     with pytest.raises(jsonschema.ValidationError):
         at_validator.validate(obj)
 

--- a/tests/test_assays.py
+++ b/tests/test_assays.py
@@ -16,7 +16,7 @@ ARTIFACT_OBJ = {
     "file_name": "dummy.txt",
     "file_size_bytes": 1,
     "data_format": "FASTA",
-    "md5_hash": "dummy",
+    "crc32c_hash": "dummy",
     "uploaded_timestamp": "dummy",
     "uploader": "dummy",
     "uuid": "dummy",

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -191,6 +191,8 @@ WESBAM_TEMPLATE_EXAMPLE_GS_URLS = {
     + "/CTTTPP121.00/wes/reads_1.bam": "bam_whatever_2_1",
 }
 
+NUM_ARTIFACT_FIELDS = 8
+
 
 def test_test_data():
 
@@ -741,6 +743,7 @@ def test_merge_artifact_wesfastq_only():
             file_size_bytes=1,
             uploaded_timestamp="01/01/2001",
             md5_hash=f"hash_{uuid}",
+            crc32c_hash=f"hash_{uuid}",
         )
 
         # assert we still have a good clinical trial object.
@@ -764,7 +767,8 @@ def test_merge_artifact_wesfastq_only():
 
     # we add 7 required fields per artifact thus `*7`
     assert (
-        len(dd["dictionary_item_added"]) == len(WES_TEMPLATE_EXAMPLE_GS_URLS) * 7
+        len(dd["dictionary_item_added"])
+        == len(WES_TEMPLATE_EXAMPLE_GS_URLS) * NUM_ARTIFACT_FIELDS
     ), "Unexpected CT changes"
 
     assert list(dd.keys()) == ["dictionary_item_added"], "Unexpected CT changes"
@@ -1002,6 +1006,7 @@ def test_end_to_end_prismify_merge_artifact_merge(xlsx, template):
             file_size_bytes=i,
             uploaded_timestamp="01/01/2001",
             md5_hash=f"hash_{i}",
+            crc32c_hash=f"hash_{i}",
         )
 
         # check that the data_format was set
@@ -1111,7 +1116,9 @@ def test_end_to_end_prismify_merge_artifact_merge(xlsx, template):
     if template.type == "wes_fastq":
 
         # 6 files * 7 artifact attributes
-        assert len(dd["dictionary_item_added"]) == 6 * 7, "Unexpected CT changes"
+        assert (
+            len(dd["dictionary_item_added"]) == 6 * NUM_ARTIFACT_FIELDS
+        ), "Unexpected CT changes"
 
         # nothing else in diff
         assert list(dd.keys()) == ["dictionary_item_added"], "Unexpected CT changes"
@@ -1119,21 +1126,25 @@ def test_end_to_end_prismify_merge_artifact_merge(xlsx, template):
     elif template.type == "wes_bam":
 
         # 4 files * 7 artifact attributes
-        assert len(dd["dictionary_item_added"]) == 4 * 7, "Unexpected CT changes"
+        assert (
+            len(dd["dictionary_item_added"]) == 4 * NUM_ARTIFACT_FIELDS
+        ), "Unexpected CT changes"
 
         # nothing else in diff
         assert list(dd.keys()) == ["dictionary_item_added"], "Unexpected CT changes"
 
     elif template.type == "ihc":
         # 2 files * 7 artifact attributes
-        assert len(dd["dictionary_item_added"]) == 2 * 7, "Unexpected CT changes"
+        assert (
+            len(dd["dictionary_item_added"]) == 2 * NUM_ARTIFACT_FIELDS
+        ), "Unexpected CT changes"
 
     elif template.type == "olink":
 
         assert list(dd.keys()) == ["dictionary_item_added"], "Unexpected CT changes"
 
         # 7 artifact attributes * 5 files (2 per record + 1 study)
-        assert len(dd["dictionary_item_added"]) == 7 * (
+        assert len(dd["dictionary_item_added"]) == NUM_ARTIFACT_FIELDS * (
             2 * 2 + 1
         ), "Unexpected CT changes"
 
@@ -1142,15 +1153,21 @@ def test_end_to_end_prismify_merge_artifact_merge(xlsx, template):
 
     elif template.type == "cytof":
         # 7 artifact attributes * 6 files
-        assert len(dd["dictionary_item_added"]) == 7 * 6, "Unexpected CT changes"
+        assert (
+            len(dd["dictionary_item_added"]) == NUM_ARTIFACT_FIELDS * 6
+        ), "Unexpected CT changes"
 
     elif template.type == "cytof_analysis":
         # 7 artifact attributes * 9 files
-        assert len(dd["dictionary_item_added"]) == 7 * 9, "Unexpected CT changes"
+        assert (
+            len(dd["dictionary_item_added"]) == NUM_ARTIFACT_FIELDS * 9
+        ), "Unexpected CT changes"
 
     elif template.type == "wes_analysis":
         # 7 artifact attributes * 124 files
-        assert len(dd["dictionary_item_added"]) == 7 * 124, "Unexpected CT changes"
+        assert (
+            len(dd["dictionary_item_added"]) == NUM_ARTIFACT_FIELDS * 124
+        ), "Unexpected CT changes"
 
     else:
         assert False, f"add {template.type} assay specific asserts"


### PR DESCRIPTION
All GCS objects will have a CRC32c hash, but only non-composite objects will have an MD5 hash. As such, update the schema to require that all artifacts have at least one of either CRC32c or MD5 hashes.