### PR TITLE
multiple gcs_uri formats as a callable/lambda in a template

### DIFF
--- a/cidc_schemas/template_writer.py
+++ b/cidc_schemas/template_writer.py
@@ -392,7 +392,15 @@ class XlTemplateWriter:
         comment = entity_schema.get("description", "")
 
         if "gcs_uri_format" in entity_schema:
-            comment += f'\nIn .{entity_schema["gcs_uri_format"].split(".")[-1]} format'
+            if isinstance(entity_schema["gcs_uri_format"], str):
+                comment += (
+                    f'\nIn .{entity_schema["gcs_uri_format"].split(".")[-1]} format'
+                )
+            elif isinstance(entity_schema["gcs_uri_format"], dict):
+                if "template_comment" in entity_schema["gcs_uri_format"]:
+                    comment += (
+                        "\n" + entity_schema["gcs_uri_format"]["template_comment"]
+                    )
 
         if comment:
             self.worksheet.write_comment(row, col, comment, self.COMMENT_THEME)

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -38,6 +38,7 @@ from cidc_schemas.prism import (
     MergeCollisionException,
     generate_analysis_configs_from_upload_patch,
     _ANALYSIS_CONF_GENERATORS,
+    _get_file_ext,
 )
 
 from cidc_schemas.json_validation import load_and_validate_schema, InDocRefNotFoundError
@@ -1423,10 +1424,11 @@ def test_prism_local_files_format_multiple_extensions(monkeypatch):
     assert "should be in one of" in str(errs[0])
 
     assert len(file_maps) == 4
-    local_exts = [l.split(".")[-1] for l in list(zip(*file_maps))[0]]
-    gcs_exts = [g.split(".")[-1] for g in list(zip(*file_maps))[1]]
-    exts = ["tif", "tiff", "svs", "qptiff"]
-    assert exts == gcs_exts == local_exts
+    expected_extensions = ["tif", "tiff", "svs", "qptiff"]
+    # check that we have only "proper" (checked by `check_errors`) extensions
+    local_extensions = [_get_file_ext(fm.local_path) for fm in file_maps]
+    gcs_extensions = [_get_file_ext(fm.gs_key) for fm in file_maps]
+    assert expected_extensions == gcs_extensions == local_extensions
 
 
 def mock_XlTemplateReader_from_excel(sheets: dict, monkeypatch):

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -1395,6 +1395,7 @@ def test_prism_local_files_format_multiple_extensions(monkeypatch):
                                     "gcs_uri_format": {
                                         "format": "lambda val, ctx: 'subfolder/'+ctx['record']+'/artifact.'+val.rsplit('.', 1)[-1]",
                                         "check_errors": "lambda val: f'Bad file type {val!r}. It should be in one of .tiff .tif .qptiff .svs formats' if val.rsplit('.', 1)[-1] not in ['svs', 'tiff', 'tif', 'qptiff'] else None",
+                                        "template_comment": "In one of .tiff .tif .qptiff .svs formats.",
                                     },
                                     "is_artifact": 1,
                                     "type_ref": "assays/components/local_file.json#properties/file_path",


### PR DESCRIPTION
This adds more flexibility to `gcs_uri_format` handling, i.e. allows for not only "static" string template format, but for any conditional logic to be implemented as `lambda` in the template.

Also adds ability for more flexible file extensions and other checks on artifact value through `check_errors` property in a template.

Please read the new test first, as it gives more background and an example of usage. 