### PR TITLE
clear fixture ids/names added

### DIFF
--- a/tests/test_clinicaltrial_examples.py
+++ b/tests/test_clinicaltrial_examples.py
@@ -35,7 +35,7 @@ def _fetch_validator():
     return jsonschema.Draft7Validator(schema)
 
 
-@pytest.mark.parametrize("example_path", example_paths())
+@pytest.mark.parametrize("example_path", example_paths(), ids=lambda x: x[1])
 def test_schema(example_path):
     validator = _fetch_validator()
 

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -474,11 +474,11 @@ def test_samples_merge():
     assert len(a3["participants"][0]["samples"]) == 2
 
 
-@pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set(),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
-)
+def repr_if_template(param):
+    return repr(param) if isinstance(param, Template) else "example"
+
+
+@pytest.mark.parametrize("xlsx, template", prismify_test_set(), ids=repr_if_template)
 def test_prism(xlsx, template):
 
     # create validators
@@ -547,11 +547,7 @@ def test_unsupported_prismify():
         prismify(None, mock_template)
 
 
-@pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set(),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
-)
+@pytest.mark.parametrize("xlsx, template", prismify_test_set(), ids=repr_if_template)
 def test_filepath_gen(xlsx, template):
 
     # TODO: every other assay
@@ -752,9 +748,7 @@ def test_filepath_gen(xlsx, template):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set("cytof"),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set("cytof"), ids=repr_if_template
 )
 def test_prismify_cytof_only(xlsx, template):
 
@@ -783,9 +777,7 @@ def test_prismify_cytof_only(xlsx, template):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set("ihc"),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set("ihc"), ids=repr_if_template
 )
 def test_prismify_ihc(xlsx, template):
 
@@ -813,9 +805,7 @@ def test_prismify_ihc(xlsx, template):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set("plasma"),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set("plasma"), ids=repr_if_template
 )
 def test_prismify_plasma(xlsx, template):
 
@@ -857,9 +847,7 @@ def assert_only_indocref_exceptions(exceptions: list):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set(filter=["wes_bam"]),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set(filter=["wes_bam"]), ids=repr_if_template
 )
 def test_prismify_wesbam_only(xlsx, template):
 
@@ -910,9 +898,7 @@ def test_prismify_wesbam_only(xlsx, template):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set("wes_fastq"),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set("wes_fastq"), ids=repr_if_template
 )
 def test_prismify_wesfastq_only(xlsx, template):
 
@@ -953,9 +939,7 @@ def test_prismify_wesfastq_only(xlsx, template):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set(filter=["rna_bam"]),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set(filter=["rna_bam"]), ids=repr_if_template
 )
 def test_prismify_rnabam_only(xlsx, template):
 
@@ -995,9 +979,7 @@ def test_prismify_rnabam_only(xlsx, template):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set("rna_fastq"),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set("rna_fastq"), ids=repr_if_template
 )
 def test_prismify_rnafastq_only(xlsx, template):
 
@@ -1034,9 +1016,7 @@ def test_prismify_rnafastq_only(xlsx, template):
 
 
 @pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set("olink"),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+    "xlsx, template", prismify_test_set("olink"), ids=repr_if_template
 )
 def test_prismify_olink_only(xlsx, template):
 
@@ -1230,11 +1210,7 @@ def test_merge_ct_meta():
     )
 
 
-@pytest.mark.parametrize(
-    "xlsx, template",
-    prismify_test_set(),
-    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
-)
+@pytest.mark.parametrize("xlsx, template", prismify_test_set(), ids=repr_if_template)
 def test_end_to_end_prismify_merge_artifact_merge(xlsx, template):
 
     assert template.type in SUPPORTED_TEMPLATES

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -474,7 +474,11 @@ def test_samples_merge():
     assert len(a3["participants"][0]["samples"]) == 2
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set())
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set(),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prism(xlsx, template):
 
     # create validators
@@ -543,7 +547,11 @@ def test_unsupported_prismify():
         prismify(None, mock_template)
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set())
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set(),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_filepath_gen(xlsx, template):
 
     # TODO: every other assay
@@ -743,7 +751,11 @@ def test_filepath_gen(xlsx, template):
         assert False, f"add {template.type} assay specific asserts"
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set("cytof"))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set("cytof"),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_cytof_only(xlsx, template):
 
     # create validators
@@ -770,7 +782,11 @@ def test_prismify_cytof_only(xlsx, template):
     validator.validate(merged)
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set("ihc"))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set("ihc"),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_ihc(xlsx, template):
 
     # create validators
@@ -796,7 +812,11 @@ def test_prismify_ihc(xlsx, template):
     validator.validate(merged)
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set("plasma"))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set("plasma"),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_plasma(xlsx, template):
 
     # create validators
@@ -836,7 +856,11 @@ def assert_only_indocref_exceptions(exceptions: list):
     assert 0 == len([e for e in exceptions if not isinstance(e, InDocRefNotFoundError)])
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set(filter=["wes_bam"]))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set(filter=["wes_bam"]),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_wesbam_only(xlsx, template):
 
     # create validators
@@ -885,7 +909,11 @@ def test_prismify_wesbam_only(xlsx, template):
     )
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set("wes_fastq"))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set("wes_fastq"),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_wesfastq_only(xlsx, template):
 
     # create validators
@@ -924,7 +952,11 @@ def test_prismify_wesfastq_only(xlsx, template):
     )
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set(filter=["rna_bam"]))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set(filter=["rna_bam"]),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_rnabam_only(xlsx, template):
 
     # create validators
@@ -962,7 +994,11 @@ def test_prismify_rnabam_only(xlsx, template):
         validator.validate(merged_wo_needed_participants)
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set("rna_fastq"))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set("rna_fastq"),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_rnafastq_only(xlsx, template):
 
     # create validators
@@ -997,7 +1033,11 @@ def test_prismify_rnafastq_only(xlsx, template):
         validator.validate(merged_wo_needed_participants)
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set("olink"))
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set("olink"),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_prismify_olink_only(xlsx, template):
 
     # create validators
@@ -1190,7 +1230,11 @@ def test_merge_ct_meta():
     )
 
 
-@pytest.mark.parametrize("xlsx, template", prismify_test_set())
+@pytest.mark.parametrize(
+    "xlsx, template",
+    prismify_test_set(),
+    ids=lambda x: repr(x) if isinstance(x, Template) else "example",
+)
 def test_end_to_end_prismify_merge_artifact_merge(xlsx, template):
 
     assert template.type in SUPPORTED_TEMPLATES

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -29,7 +29,7 @@ def schema_paths():
     return schema_paths
 
 
-@pytest.mark.parametrize("schema_path", schema_paths())
+@pytest.mark.parametrize("schema_path", schema_paths(), ids=lambda x: x.split("/")[-1])
 def test_schema(schema_path):
     """Ensure the schema file conforms to JSON schema draft 7"""
     assert load_and_validate_schema(schema_path)

--- a/tests/test_unprism.py
+++ b/tests/test_unprism.py
@@ -53,7 +53,7 @@ def test_build_artifact():
     )
 
 
-@pytest.mark.parametrize("upload_type", SUPPORTED_SHIPPING_MANIFESTS)
+@pytest.mark.parametrize("upload_type", SUPPORTED_SHIPPING_MANIFESTS, ids=lambda x: x)
 def test_derive_files_shipping_manifest(ct, upload_type):
     """Check that participants and samples CSVs are derived as expected."""
     result = derive_files(DeriveFilesContext(ct, upload_type, None))


### PR DESCRIPTION
adds "names" for parametrized fixtures - so they appear when you run `pytest -v` like that (in square brackets)
```
tests/test_clinicaltrial_examples.py::test_schema[CT_1PA_multiWES.json] PASSED [ 20%]
tests/test_clinicaltrial_examples.py::test_schema[CT_1.json] PASSED      [ 40%]
tests/test_clinicaltrial_examples.py::test_schema[CT_minimal.json] 
```