### PR TITLE
Add lru_cache decorator to load_and_validate_schema

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.6"
+__version__ = "0.16.7"

--- a/cidc_schemas/json_validation.py
+++ b/cidc_schemas/json_validation.py
@@ -7,6 +7,7 @@ import json
 import copy
 import fnmatch
 import collections.abc
+import functools
 from typing import Optional, List, Callable, Union
 
 import dateparser
@@ -316,6 +317,7 @@ def _load_dont_validate_schema(
 _validator_instance = _Validator({})
 
 
+@functools.lru_cache(maxsize=32)
 def load_and_validate_schema(
     schema_path: str,
     schema_root: str = SCHEMA_DIR,
@@ -333,6 +335,10 @@ def load_and_validate_schema(
         return schema
     else:
         return _Validator(schema)
+
+
+# Warm up the cache with a full clinical trial validator
+load_and_validate_schema("clinical_trial.json", return_validator=True)
 
 
 def validate_instance(instance: str, schema: dict, is_required=False) -> Optional[str]:

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -324,7 +324,7 @@ def test_validator_speed(benchmark):
         except:
             raise
 
-    benchmark.pedantic(do_validation, rounds=5)
+    benchmark.pedantic(do_validation, rounds=3)
 
 
 def test_special_keywords():

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -1082,6 +1082,25 @@ def test_merge_artifact_none_md5():
         )
 
 
+def test_merge_artifact_wesfastq_benchmark(benchmark):
+    ct = copy.deepcopy(TEST_PRISM_TRIAL)
+    url, uuid = list(WES_TEMPLATE_EXAMPLE_GS_URLS.items())[0]
+
+    def merge():
+        merge_artifact(
+            ct,
+            assay_type="wes",
+            artifact_uuid=uuid,
+            object_url=url,
+            file_size_bytes=1,
+            uploaded_timestamp="01/01/2001",
+            md5_hash=f"hash_{uuid}",
+            crc32c_hash=f"hash_{uuid}",
+        )
+
+    benchmark.pedantic(merge, rounds=10)
+
+
 def test_merge_artifact_wesfastq_only():
 
     # create the clinical trial.


### PR DESCRIPTION
The benchmark in this PR suggests caching leads to a 100x speedup when calling `merge_artifact`. We can expect some speed up anywhere that `load_and_validate_schema` is currently called.