### PR TITLE
Improve the coverage of (mostly) generic prism functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cidc-schemas
-| Branch                                               | Status                                                                                                                            | Maintainability | Test Coverage |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --- | --- |
+| Branch                                               | Status                                                                                                                            | Maintainability                                                                                                                                                          | Test Coverage                                                                                                                                                      |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [master](https://cimac-cidc.github.io/cidc-schemas/) | [![Build Status](https://travis-ci.org/CIMAC-CIDC/cidc-schemas.svg?branch=master)](https://travis-ci.org/CIMAC-CIDC/cidc-schemas) | [![Maintainability](https://api.codeclimate.com/v1/badges/3f989b974663df81ef45/maintainability)](https://codeclimate.com/github/CIMAC-CIDC/cidc-schemas/maintainability) | [![Test Coverage](https://api.codeclimate.com/v1/badges/3f989b974663df81ef45/test_coverage)](https://codeclimate.com/github/CIMAC-CIDC/cidc-schemas/test_coverage) |
 
 This repository contains formal definitions of the CIDC metadata model using [json-schema](https://json-schema.org/) syntax and vocabulary.
@@ -110,12 +110,4 @@ Check that a JSON schema conforms to the JSON Schema specifications.
 
 ```bash
 cidc_schemas validate_schema -f shipping_core.json
-```
-
-### Convert between yaml and json
-
-The CLI comes with a little utility for converting between yaml and json files.
-
-```bash
-cidc_schemas convert --to_json <some_yaml_file>
 ```

--- a/cidc_schemas/cli.py
+++ b/cidc_schemas/cli.py
@@ -93,18 +93,6 @@ def interface() -> argparse.Namespace:
     )
     schema_parser.set_defaults(func=validate_schema)
 
-    # Parser for schema file format conversion
-    conversion_parser = subparsers.add_parser(
-        "convert", help="Convert a yaml file to a json file, or vice versa"
-    )
-    conversion_parser.add_argument(
-        "--to_json", help="Path to yaml file to convert to json"
-    )
-    conversion_parser.add_argument(
-        "--to_yaml", help="Path to json file to convert to yaml"
-    )
-    conversion_parser.set_defaults(func=convert)
-
     return parser.parse_args()
 
 
@@ -142,15 +130,6 @@ def validate_schema(args: argparse.Namespace):
     success = load_and_validate_schema(args.schema_file, abs_schemas_dir)
     if success:
         print(f"{args.schema_file} is valid")
-
-
-def convert(args: argparse.Namespace):
-    if args.to_json:
-        json_file = util.yaml_to_json(args.to_json)
-        print(f"Wrote {args.to_json} as json to {json_file}")
-    elif args.to_yaml:
-        yaml_file = util.json_to_yaml(args.to_yaml)
-        print(f"Wrote {args.to_yaml} as yaml to {yaml_file}")
 
 
 if __name__ == "__main__":

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -128,7 +128,7 @@ def _set_val(
         # check that we don't have to jump up more than we dived in already
         assert jumpups <= context_pointer.rstrip("/").count(
             "/"
-        ), f"Can't set value for pointer {pointer} to many jumps up from current context."
+        ), f"Can't set value for pointer {pointer} too many jumps up from current context."
 
         # and we'll go down remaining part of `pointer` from there
         jpoint = JsonPointer(slash + rem_pointer)
@@ -227,34 +227,6 @@ def __jpointer_insert_next_thing(doc, jpoint, part, next_thing):
             doc.append(next_thing)
 
 
-def _get_recursively(search_dict, field):
-    """
-    Takes a dict with nested lists and dicts,
-    and searches all dicts for a key of the field
-    provided.
-    """
-    fields_found = []
-
-    for key, value in search_dict.items():
-
-        if key == field:
-            fields_found.append(value)
-
-        elif isinstance(value, dict):
-            results = _get_recursively(value, field)
-            for result in results:
-                fields_found.append(result)
-
-        elif isinstance(value, list):
-            for item in value:
-                if isinstance(item, dict):
-                    more_results = _get_recursively(item, field)
-                    for another_result in more_results:
-                        fields_found.append(another_result)
-
-    return fields_found
-
-
 SUPPORTED_ASSAYS = [
     "wes_fastq",
     "wes_bam",
@@ -303,7 +275,7 @@ def _process_property(
     where it needs to go in the final object, then inserts it.
     Args:
         key: property name,
-        raw_val: value of a property being processed,
+        raw_val: value of a property beng processed,
         key_lu: dictionary to translate from template naming to json-schema
                 property names
         data_obj: dictionary we are building to represent data
@@ -514,7 +486,6 @@ def _calc_val_and_files(raw_val, field_def: dict, format_context: dict):
 
     else:
         logger.debug(f"      collecting local_file_path {field_def}")
-
         files.append(
             _format_single_artifact(
                 local_path=raw_val,

--- a/cidc_schemas/prism.py
+++ b/cidc_schemas/prism.py
@@ -275,7 +275,7 @@ def _process_property(
     where it needs to go in the final object, then inserts it.
     Args:
         key: property name,
-        raw_val: value of a property beng processed,
+        raw_val: value of a property being processed,
         key_lu: dictionary to translate from template naming to json-schema
                 property names
         data_obj: dictionary we are building to represent data

--- a/cidc_schemas/util.py
+++ b/cidc_schemas/util.py
@@ -136,37 +136,3 @@ def get_source(ct: dict, key: str, skip_last=None) -> (JSON, JSON):
         _update_extra_metadata(last_token, cur_obj, namespace)
 
     return cur_obj, extra_metadata
-
-
-def yaml_to_json(yaml_path: str) -> str:
-    """
-        Given a path to a yaml file, write the equivalent json
-        to a file of the same name and return the new filename.
-    """
-    filename, ext = yaml_path.rsplit(".", 1)
-    assert ext == "yaml", "expected a yaml file"
-
-    with open(yaml_path, "r") as stream:
-        dictionary = yaml.safe_load(stream)
-        json_path = f"{filename}.json"
-        with open(json_path, "w") as new_file:
-            json.dump(dictionary, new_file, indent=2)
-
-    return json_path
-
-
-def json_to_yaml(json_path: str) -> str:
-    """
-        Given a path to a json file, write the equivalent yaml
-        to a file of the same name and return the new filename.
-    """
-    filename, ext = json_path.rsplit(".", 1)
-    assert ext == "json", "expected a json file"
-
-    with open(json_path, "r") as stream:
-        dictionary = json.load(stream)
-        yaml_path = f"{filename}.yaml"
-        with open(yaml_path, "w") as new_file:
-            yaml.safe_dump(dictionary, new_file)
-
-    return yaml_path

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -1734,15 +1734,13 @@ def test_set_val():
 
     # _set_val should throw an exception given a value pointer with too many jumps
     with pytest.raises(AssertionError, match="too many jumps up"):
-        prism._set_val("3/prop1/prop2", {"more": "props"}, context, root, "/prop0/0")
+        prism._set_val("3/prop1/prop2", {}, {}, {}, "/prop0/0")
 
     # _set_val should throw an exception given an invalid context pointer
-    context = {"Pid": 1}
-    root = {"prop0": [context]}
+    one_jumpup_pointer = "1/prop1"
+    invalid_context_pointer = "/foo/bar"
     with pytest.raises(Exception, match="member 'foo' not found"):
-        prism._set_val(
-            "1/prop1/prop2", {"more": "props"}, context, root, "foo/bar/buzz/baz"
-        )
+        prism._set_val(one_jumpup_pointer, {}, {}, {}, invalid_context_pointer)
 
 
 def test_process_property():
@@ -1761,7 +1759,7 @@ def test_process_property():
     assert files == []
 
     # _process_property catches unparseable raw values
-    with pytest.raises(prism.ParsingException, match="Can't parse 'prop0'"):
+    with pytest.raises(prism.ParsingException, match=f"Can't parse {prop!r}"):
         prism._process_property(prop, "123abcd", {prop: prop_def}, {}, {})
 
     # _process_property catches a missing gcs_uri_format on an artifact


### PR DESCRIPTION
...also, remove some stale, unused code.

Possibly TODO (**update**: deferring to future PRs):
* [ ] somehow separate generic prism tests from CIDC schemas-specific tests
* [ ] consider finding a way to cover helper function code by calling entry point functions rather than the helpers themselves