### PR TITLE
Fix field name typo and make cohort_name optional

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.19"
+__version__ = "0.16.20"

--- a/cidc_schemas/schemas/clinical_trial.json
+++ b/cidc_schemas/schemas/clinical_trial.json
@@ -30,7 +30,7 @@
       "description": "Name of the primary organization that oversees the clinical trial. Example: ECOG-ACRIN, SWOG, etc.",
       "type": "string"
     },
-    "grant_of_affiliated_network": {
+    "grant_or_affiliated_network": {
       "description": "The primary organization providing grant funding and supporting the trial.",
       "type": "string"
     },

--- a/cidc_schemas/schemas/participant.json
+++ b/cidc_schemas/schemas/participant.json
@@ -29,7 +29,7 @@
         "Arm_A",
         "Arm_B",
         "Arm_C",
-        "Arm_D", 
+        "Arm_D",
         "Arm_E",
         "Arm_F",
         "Arm_G",
@@ -62,7 +62,7 @@
         "Arm_A": "E4412 or 10026",
         "Arm_B": "E4412 or 10026",
         "Arm_C": "E4412",
-        "Arm_D": "E4412", 
+        "Arm_D": "E4412",
         "Arm_E": "E4412",
         "Arm_F": "E4412",
         "Arm_G": "E4412",
@@ -90,8 +90,8 @@
       }
     },
     "essential_patient_entry_number": {
-        "description": "Provides a numbered identifier for patient (sample) entry in a shipment manifest.",
-        "type": "integer"
+      "description": "Provides a numbered identifier for patient (sample) entry in a shipment manifest.",
+      "type": "integer"
     },
     "gender": {
       "type": "string",
@@ -134,9 +134,5 @@
       }
     }
   },
-  "required": [
-    "cimac_participant_id",
-    "participant_id",
-    "cohort_name",
-    "samples"]
+  "required": ["cimac_participant_id", "participant_id", "samples"]
 }


### PR DESCRIPTION
Though it's true that all participants in a clinical trial need a `cohort_name`, we've decided that for the new trial management system, not knowing a participant's cohort shouldn't block adding that participant to a trial.

(Apologies for some of the accidental autoformatting in this PR)