### PR TITLE
Add collection event biospecimen tree

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.21"
+__version__ = "0.16.22"

--- a/cidc_schemas/schemas/clinical_trial.json
+++ b/cidc_schemas/schemas/clinical_trial.json
@@ -70,22 +70,10 @@
       "description": "A description of the rules governing data sharing and publications.",
       "type": "string"
     },
-    "collection_event_matrix": {
+    "collection_event_list": {
       "description": "A list associating collection events with allowed sample types.",
       "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "collection_event": {
-            "type": "string"
-          },
-          "sample_types": {
-            "type": "array",
-            "items": { "type": "string" }
-          }
-        }
-      }
+      "items": { "$ref": "collection_event.json" }
     },
     "allowed_collection_event_names": {
       "description": "Allowed values for sample.json#properties/collection_event_name for this trial.",

--- a/cidc_schemas/schemas/collection_event.json
+++ b/cidc_schemas/schemas/collection_event.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "metaschema/strict_meta_schema.json#",
+  "$id": "collection_event.json",
+  "description": "Defines a collection event and its biospecimen type hierarchy.",
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "specimen_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "specimen_type": {
+          "$comment": "The name of this specimen type",
+          "type": "string"
+        },
+        "derivatives": {
+          "$comment": "The derivate specimen types for this specimen type (e.g., plasma is derived from whole blood).",
+          "type": "array",
+          "items": { "$ref": "#/definitions/specimen_type" }
+        },
+        "intended_assays": {
+          "$comment": "The assay(s) with which this biospecimen will be analyzed.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "comments": { "type": "string" }
+      },
+      "required": ["specimen_type"]
+    }
+  },
+  "properties": {
+    "event_name": {
+      "$comment": "The name of this collection event",
+      "type": "string"
+    },
+    "specimen_types": {
+      "$comment": "The array of root specimen types associated with this collection event",
+      "type": "array",
+      "items": { "$ref": "#/definitions/specimen_type" }
+    }
+  }
+}

--- a/tests/data/clinicaltrial_examples/CT_1.json
+++ b/tests/data/clinicaltrial_examples/CT_1.json
@@ -1,413 +1,536 @@
 {
-    "protocol_identifier": "10021",
-    "allowed_collection_event_names": [
-        "Baseline"
-    ],
-    "allowed_cohort_names": [
-        "Arm_Z"
-    ],
-    "participants": [
+  "protocol_identifier": "10021",
+  "allowed_collection_event_names": ["Baseline"],
+  "allowed_cohort_names": ["Arm_Z"],
+  "collection_event_list": [
+    {
+      "event_name": "Baseline",
+      "specimen_types": [
         {
-            "cimac_participant_id": "CTTTPP1",
-            "participant_id": "trial.PA.1",
-            "cohort_name": "Arm_Z",
-            "samples": [
-                {
-                    "cimac_id": "CTTTPP1S1.00",
-                    "parent_sample_id": "SA.1.1",
-                    "collection_event_name": "Baseline",
-                    "sample_location": "---",
-                    "type_of_sample": "Other",
-                    "type_of_primary_container": "Other",
-                    "sample_volume_units": "Other",
-                    "material_used": 1,
-                    "material_remaining": 0,
-                    "quality_of_sample": "Other",
-                    "aliquots": [
-                        {
-                            "slide_number": "1",
-                            "aliquot_replacement": "N/A",
-                            "aliquot_status": "Other"
-                        }
-                    ] 
-                }, 
-                {
-                    "cimac_id": "CTTTPP1S2.00",
-                    "parent_sample_id": "SA.1.2",
-                    "collection_event_name": "Baseline",
-                    "sample_location": "---",
-                    "type_of_sample": "Other",
-                    "type_of_primary_container": "Other",
-                    "sample_volume_units": "Other",
-                    "material_used": 1,
-                    "material_remaining": 0,
-                    "quality_of_sample": "Other",
-                    "aliquots": [
-                        {
-                            "slide_number": "1",
-                            "aliquot_replacement": "N/A",
-                            "aliquot_status": "Other"
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "cimac_participant_id": "CTTTPP2",
-            "participant_id": "trial.PA.2",
-            "cohort_name": "Arm_Z",
-            "samples": [
-                {
-                    "cimac_id": "CTTTPP2S1.00",
-                    "parent_sample_id": "SA.2.1",
-                    "collection_event_name": "Baseline",
-                    "sample_location": "---",
-                    "type_of_sample": "Other",
-                    "type_of_primary_container": "Other",
-                    "sample_volume_units": "Other",
-                    "material_used": 1,
-                    "material_remaining": 0,
-                    "quality_of_sample": "Other",
-                    "aliquots": [
-                        {
-                            "slide_number": "1",
-                            "aliquot_replacement": "N/A",
-                            "aliquot_status": "Other"
-                        }
-                    ]
-                },
-                {
-                    "cimac_id": "CTTTPP2S2.00",
-                    "parent_sample_id": "SA.2.2",
-                    "collection_event_name": "Baseline",
-                    "sample_location": "---",
-                    "type_of_sample": "Other",
-                    "type_of_primary_container": "Other",
-                    "sample_volume_units": "Other",
-                    "material_used": 1,
-                    "material_remaining": 0,
-                    "quality_of_sample": "Other",
-                    "aliquots": [
-                        {
-                            "slide_number": "1",
-                            "aliquot_replacement": "N/A",
-                            "aliquot_status": "Other"
-                        }
-                    ]
-                }
-            ]
+          "specimen_type": "Whole Blood",
+          "derivatives": [
+            { "specimen_type": "Plasma", "intended_assays": ["CyTOF"] },
+            { "specimen_type": "PBMC", "intended_assays": ["Olink"] }
+          ]
         }
-    ],
-    "assays": {
-        "olink": {
-            "assay_creator": "Mount Sinai",
-            "panel": "ol_panel_1",
-            "study": {
-                "npx_manager_version": "ol_npx_v1",
-                "study_npx": {
-                    "file_name" :           "...",
-                    "object_url" :          "...",
-                    "uploaded_timestamp" :  "...",
-                    "file_size_bytes" :     0,
-                    "md5_hash" :            "...",
-                    "artifact_category" :   "Assay Artifact from CIMAC",
-                    "data_format" :           "NPX",
-                    "number_of_samples":   6,
-                    "samples": ["CTTTPP2S2.01", "CTTTPP1S1.01", "CTTTPP2S1.01", "CTTTPP2S2.00", "CTTTPP1S1.00", "CTTTPP2S1.00"]
-                }
-            },
-            "records": [
+      ]
+    },
+    {
+      "event_name": "Week7",
+      "specimen_types": [
+        {
+          "specimen_type": "Whole Blood",
+          "derivatives": [
+            {
+              "specimen_type": "Plasma",
+              "intended_assays": ["CyTOF"],
+              "derivatives": [
                 {
-                    "number_of_samples": 88,
-                    "npx_manager_version": "ol_npx_v1",
-                    "files": {
-                        "assay_npx": {
-                            "file_name" :           "...",
-                            "object_url" :          "...",
-                            "uploaded_timestamp" :  "...",
-                            "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
-                            "artifact_category" :   "Assay Artifact from CIMAC",
-                            "data_format" :           "NPX",
-                            "number_of_samples":   3,
-                            "samples": ["CTTTPP2S2.01", "CTTTPP1S1.01", "CTTTPP2S1.01"]
-                        },
-                        "assay_raw_ct": {
-                            "file_name" :           "...",
-                            "object_url" :          "...",
-                            "uploaded_timestamp" :  "...",
-                            "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
-                            "artifact_category" :   "Assay Artifact from CIMAC",
-                            "data_format" :         "CSV"
-                        }
-                    }
-                }, 
-                {
-                    "number_of_samples": 45,
-                    "npx_manager_version": "ol_npx_v1",
-                    "files": {
-                        "assay_npx": {
-                            "file_name" :           "...",
-                            "object_url" :          "...",
-                            "uploaded_timestamp" :  "...",
-                            "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
-                            "artifact_category" :   "Assay Artifact from CIMAC",
-                            "data_format" :           "NPX",
-                            "number_of_samples":   3,
-                            "samples": ["CTTTPP2S2.00", "CTTTPP1S1.00", "CTTTPP2S1.00"]
-                        },
-                        "assay_raw_ct": {
-                            "file_name" :           "...",
-                            "object_url" :          "...",
-                            "uploaded_timestamp" :  "...",
-                            "file_size_bytes" :     0,
-                            "md5_hash" :            "...",
-                            "artifact_category" :   "Assay Artifact from CIMAC",
-                            "data_format" :         "CSV"
-                        }
-                    }
+                  "specimen_type": "DNA",
+                  "intended_assays": ["WES"]
                 }
-            ]
-        },
-        "wes": [
-            {
-                "assay_creator": "Mount Sinai",
-                "paired_end_reads": "Paired",
-                "read_length": 100,
-                "sequencer_platform": "Illumina - HiSeq 3000",
-                "library_kit": "Hyper Prep ICE Exome Express: 1.0",
-                "sequencing_protocol": "Express Somatic Human WES (Deep Coverage) v1.1",
-                "bait_set": "whole_exome_illumina_coding_v1",
-                "records": [
-                    {
-                        "cimac_id":          "CTTTPP1S1.00",
-                        "sequencing_date": "...",
-                        "quality_flag": 1,
-                        "files": {
-                            "r1": [{
-                                    "file_name" :           "...",
-                                    "object_url" :          "...",
-                                    "uploaded_timestamp" :  "...",
-                                    "file_size_bytes" :     0,
-                                    "md5_hash" :            "...",
-                                    "artifact_category" :   "Assay Artifact from CIMAC",
-                                    "data_format":          "FASTQ.GZ"
-                            }],
-                            "r2": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format":          "FASTQ.GZ"
-                            }]
-                        }
-                    },
-                    {
-                        "cimac_id":          "CTTTPP1S2.00",
-                        "sequencing_date": "...",
-                        "quality_flag": 1,
-                        "files": {
-                            "bam": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "BAM"
-                            }]
-                        }
-                    }
-                ]
+              ]
             },
-            {
-                "assay_creator": "Mount Sinai",
-                "paired_end_reads": "Paired",
-                "read_length": 100,
-                "sequencer_platform": "Illumina - HiSeq 3000",
-                "library_kit": "Hyper Prep ICE Exome Express: 1.0",
-                "sequencing_protocol": "Express Somatic Human WES (Deep Coverage) v1.1",
-                "bait_set": "whole_exome_illumina_coding_v1",
-                "records": [
-                    {
-                        "cimac_id":          "CTTTPP2S1.00",
-                        "sequencing_date": "...",
-                        "quality_flag": 1,
-                        "files": {
-                            "r1": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }],
-                            "r2": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }]
-                        }
-                    },
-                    {
-                        "cimac_id":          "CTTTPP2S2.00",
-                        "sequencing_date": "...",
-                        "quality_flag": 1,
-                        "files": {
-                            "r1": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }],
-                            "r2": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }]
-                        }
-                    }
-                ]
-            }
-        ],
-        "rna": [
-            {
-                "assay_creator": "Mount Sinai",
-                "paired_end_reads": "Paired",
-                "enrichment_method": "Ribo minus",
-                "enrichment_vendor_kit": "Agilent",
-                "sequencer_platform": "Illumina - HiSeq 3000",
-                "records": [
-                    {
-                        "cimac_id":          "CTTTPP1S1.00",
-                        "library_yield_ng": 666,
-                        "dv200": 0.7,
-                        "rqs": 8,
-                        "rin": 8,
-                        "quality_flag": 1,
-                        "files": {
-                            "r1": [{
-                                    "file_name" :           "...",
-                                    "object_url" :          "...",
-                                    "uploaded_timestamp" :  "...",
-                                    "file_size_bytes" :     0,
-                                    "md5_hash" :            "...",
-                                    "artifact_category" :   "Assay Artifact from CIMAC",
-                                    "data_format":          "FASTQ.GZ"
-                            }],
-                            "r2": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format":          "FASTQ.GZ"
-                            }]
-                        }
-                    },
-                    {
-                        "cimac_id":          "CTTTPP1S2.00",
-                        "library_yield_ng": 666,
-                        "dv200": 0.7,
-                        "rqs": 8,
-                        "rin": 8,
-                        "quality_flag": 1,
-                        "files": {
-                            "bam": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "BAM"
-                            }]
-                        }
-                    }
-                ]
-            },
-            {
-                "assay_creator": "Mount Sinai",
-                "paired_end_reads": "Paired",
-                "enrichment_method": "Ribo minus",
-                "enrichment_vendor_kit": "Agilent",
-                "sequencer_platform": "Illumina - HiSeq 3000",
-                "records": [
-                    {
-                        "cimac_id":          "CTTTPP2S1.00",
-                        "library_yield_ng": 666,
-                        "dv200": 0.7,
-                        "rqs": 8,
-                        "rin": 8,
-                        "quality_flag": 1,
-                        "files": {
-                            "r1": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }],
-                            "r2": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }]
-                        }
-                    },
-                    {
-                        "cimac_id":          "CTTTPP2S2.00",
-                        "quality_flag": 1,
-                        "library_yield_ng": 666,
-                        "dv200": 0.7,
-                        "rqs": 8,
-                        "rin": 8,
-                        "files": {
-                            "r1": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }],
-                            "r2": [{
-                                "file_name" :           "...",
-                                "object_url" :          "...",
-                                "uploaded_timestamp" :  "...",
-                                "file_size_bytes" :     0,
-                                "md5_hash" :            "...",
-                                "artifact_category" :   "Assay Artifact from CIMAC",
-                                "data_format" :           "FASTQ.GZ"
-                            }]
-                        }
-                    }
-                ]
-            }
-        ]
+            { "specimen_type": "PBMC", "intended_assays": ["Olink"] }
+          ]
+        }
+      ]
     }
+  ],
+  "participants": [
+    {
+      "cimac_participant_id": "CTTTPP1",
+      "participant_id": "trial.PA.1",
+      "cohort_name": "Arm_Z",
+      "samples": [
+        {
+          "cimac_id": "CTTTPP1S1.00",
+          "parent_sample_id": "SA.1.1",
+          "collection_event_name": "Baseline",
+          "sample_location": "---",
+          "type_of_sample": "Other",
+          "type_of_primary_container": "Other",
+          "sample_volume_units": "Other",
+          "material_used": 1,
+          "material_remaining": 0,
+          "quality_of_sample": "Other",
+          "aliquots": [
+            {
+              "slide_number": "1",
+              "aliquot_replacement": "N/A",
+              "aliquot_status": "Other"
+            }
+          ]
+        },
+        {
+          "cimac_id": "CTTTPP1S1.01",
+          "parent_sample_id": "SA.1.1",
+          "collection_event_name": "Baseline",
+          "sample_location": "---",
+          "type_of_sample": "Other",
+          "type_of_primary_container": "Other",
+          "sample_volume_units": "Other",
+          "material_used": 1,
+          "material_remaining": 0,
+          "quality_of_sample": "Other",
+          "aliquots": [
+            {
+              "slide_number": "1",
+              "aliquot_replacement": "N/A",
+              "aliquot_status": "Other"
+            }
+          ]
+        },
+        {
+          "cimac_id": "CTTTPP1S2.00",
+          "parent_sample_id": "SA.1.2",
+          "collection_event_name": "Baseline",
+          "sample_location": "---",
+          "type_of_sample": "Other",
+          "type_of_primary_container": "Other",
+          "sample_volume_units": "Other",
+          "material_used": 1,
+          "material_remaining": 0,
+          "quality_of_sample": "Other",
+          "aliquots": [
+            {
+              "slide_number": "1",
+              "aliquot_replacement": "N/A",
+              "aliquot_status": "Other"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "cimac_participant_id": "CTTTPP2",
+      "participant_id": "trial.PA.2",
+      "cohort_name": "Arm_Z",
+      "samples": [
+        {
+          "cimac_id": "CTTTPP2S1.00",
+          "parent_sample_id": "SA.2.1",
+          "collection_event_name": "Baseline",
+          "sample_location": "---",
+          "type_of_sample": "Other",
+          "type_of_primary_container": "Other",
+          "sample_volume_units": "Other",
+          "material_used": 1,
+          "material_remaining": 0,
+          "quality_of_sample": "Other",
+          "aliquots": [
+            {
+              "slide_number": "1",
+              "aliquot_replacement": "N/A",
+              "aliquot_status": "Other"
+            }
+          ]
+        },
+        {
+          "cimac_id": "CTTTPP2S1.01",
+          "parent_sample_id": "SA.2.1",
+          "collection_event_name": "Baseline",
+          "sample_location": "---",
+          "type_of_sample": "Other",
+          "type_of_primary_container": "Other",
+          "sample_volume_units": "Other",
+          "material_used": 1,
+          "material_remaining": 0,
+          "quality_of_sample": "Other",
+          "aliquots": [
+            {
+              "slide_number": "1",
+              "aliquot_replacement": "N/A",
+              "aliquot_status": "Other"
+            }
+          ]
+        },
+        {
+          "cimac_id": "CTTTPP2S2.00",
+          "parent_sample_id": "SA.2.2",
+          "collection_event_name": "Baseline",
+          "sample_location": "---",
+          "type_of_sample": "Other",
+          "type_of_primary_container": "Other",
+          "sample_volume_units": "Other",
+          "material_used": 1,
+          "material_remaining": 0,
+          "quality_of_sample": "Other",
+          "aliquots": [
+            {
+              "slide_number": "1",
+              "aliquot_replacement": "N/A",
+              "aliquot_status": "Other"
+            }
+          ]
+        },
+        {
+          "cimac_id": "CTTTPP2S2.01",
+          "parent_sample_id": "SA.2.2",
+          "collection_event_name": "Baseline",
+          "sample_location": "---",
+          "type_of_sample": "Other",
+          "type_of_primary_container": "Other",
+          "sample_volume_units": "Other",
+          "material_used": 1,
+          "material_remaining": 0,
+          "quality_of_sample": "Other",
+          "aliquots": [
+            {
+              "slide_number": "1",
+              "aliquot_replacement": "N/A",
+              "aliquot_status": "Other"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "assays": {
+    "olink": {
+      "assay_creator": "Mount Sinai",
+      "panel": "ol_panel_1",
+      "study": {
+        "npx_manager_version": "ol_npx_v1",
+        "study_npx": {
+          "file_name": "...",
+          "object_url": "...",
+          "uploaded_timestamp": "...",
+          "file_size_bytes": 0,
+          "md5_hash": "...",
+          "artifact_category": "Assay Artifact from CIMAC",
+          "data_format": "NPX",
+          "number_of_samples": 6,
+          "samples": [
+            "CTTTPP2S2.01",
+            "CTTTPP1S1.01",
+            "CTTTPP2S1.01",
+            "CTTTPP2S2.00",
+            "CTTTPP1S1.00",
+            "CTTTPP2S1.00"
+          ]
+        }
+      },
+      "records": [
+        {
+          "number_of_samples": 88,
+          "npx_manager_version": "ol_npx_v1",
+          "files": {
+            "assay_npx": {
+              "file_name": "...",
+              "object_url": "...",
+              "uploaded_timestamp": "...",
+              "file_size_bytes": 0,
+              "md5_hash": "...",
+              "artifact_category": "Assay Artifact from CIMAC",
+              "data_format": "NPX",
+              "number_of_samples": 3,
+              "samples": ["CTTTPP2S2.01", "CTTTPP1S1.01", "CTTTPP2S1.01"]
+            },
+            "assay_raw_ct": {
+              "file_name": "...",
+              "object_url": "...",
+              "uploaded_timestamp": "...",
+              "file_size_bytes": 0,
+              "md5_hash": "...",
+              "artifact_category": "Assay Artifact from CIMAC",
+              "data_format": "CSV"
+            }
+          }
+        },
+        {
+          "number_of_samples": 45,
+          "npx_manager_version": "ol_npx_v1",
+          "files": {
+            "assay_npx": {
+              "file_name": "...",
+              "object_url": "...",
+              "uploaded_timestamp": "...",
+              "file_size_bytes": 0,
+              "md5_hash": "...",
+              "artifact_category": "Assay Artifact from CIMAC",
+              "data_format": "NPX",
+              "number_of_samples": 3,
+              "samples": ["CTTTPP2S2.00", "CTTTPP1S1.00", "CTTTPP2S1.00"]
+            },
+            "assay_raw_ct": {
+              "file_name": "...",
+              "object_url": "...",
+              "uploaded_timestamp": "...",
+              "file_size_bytes": 0,
+              "md5_hash": "...",
+              "artifact_category": "Assay Artifact from CIMAC",
+              "data_format": "CSV"
+            }
+          }
+        }
+      ]
+    },
+    "wes": [
+      {
+        "assay_creator": "Mount Sinai",
+        "paired_end_reads": "Paired",
+        "read_length": 100,
+        "sequencer_platform": "Illumina - HiSeq 3000",
+        "library_kit": "Hyper Prep ICE Exome Express: 1.0",
+        "sequencing_protocol": "Express Somatic Human WES (Deep Coverage) v1.1",
+        "bait_set": "whole_exome_illumina_coding_v1",
+        "records": [
+          {
+            "cimac_id": "CTTTPP1S1.00",
+            "sequencing_date": "...",
+            "quality_flag": 1,
+            "files": {
+              "r1": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ],
+              "r2": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ]
+            }
+          },
+          {
+            "cimac_id": "CTTTPP1S2.00",
+            "sequencing_date": "...",
+            "quality_flag": 1,
+            "files": {
+              "bam": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "BAM"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "assay_creator": "Mount Sinai",
+        "paired_end_reads": "Paired",
+        "read_length": 100,
+        "sequencer_platform": "Illumina - HiSeq 3000",
+        "library_kit": "Hyper Prep ICE Exome Express: 1.0",
+        "sequencing_protocol": "Express Somatic Human WES (Deep Coverage) v1.1",
+        "bait_set": "whole_exome_illumina_coding_v1",
+        "records": [
+          {
+            "cimac_id": "CTTTPP2S1.00",
+            "sequencing_date": "...",
+            "quality_flag": 1,
+            "files": {
+              "r1": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ],
+              "r2": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ]
+            }
+          },
+          {
+            "cimac_id": "CTTTPP2S2.00",
+            "sequencing_date": "...",
+            "quality_flag": 1,
+            "files": {
+              "r1": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ],
+              "r2": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "rna": [
+      {
+        "assay_creator": "Mount Sinai",
+        "paired_end_reads": "Paired",
+        "enrichment_method": "Ribo minus",
+        "enrichment_vendor_kit": "Agilent",
+        "sequencer_platform": "Illumina - HiSeq 3000",
+        "records": [
+          {
+            "cimac_id": "CTTTPP1S1.00",
+            "library_yield_ng": 666,
+            "dv200": 0.7,
+            "rqs": 8,
+            "rin": 8,
+            "quality_flag": 1,
+            "files": {
+              "r1": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ],
+              "r2": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ]
+            }
+          },
+          {
+            "cimac_id": "CTTTPP1S2.00",
+            "library_yield_ng": 666,
+            "dv200": 0.7,
+            "rqs": 8,
+            "rin": 8,
+            "quality_flag": 1,
+            "files": {
+              "bam": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "BAM"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "assay_creator": "Mount Sinai",
+        "paired_end_reads": "Paired",
+        "enrichment_method": "Ribo minus",
+        "enrichment_vendor_kit": "Agilent",
+        "sequencer_platform": "Illumina - HiSeq 3000",
+        "records": [
+          {
+            "cimac_id": "CTTTPP2S1.00",
+            "library_yield_ng": 666,
+            "dv200": 0.7,
+            "rqs": 8,
+            "rin": 8,
+            "quality_flag": 1,
+            "files": {
+              "r1": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ],
+              "r2": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ]
+            }
+          },
+          {
+            "cimac_id": "CTTTPP2S2.00",
+            "quality_flag": 1,
+            "library_yield_ng": 666,
+            "dv200": 0.7,
+            "rqs": 8,
+            "rin": 8,
+            "files": {
+              "r1": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ],
+              "r2": [
+                {
+                  "file_name": "...",
+                  "object_url": "...",
+                  "uploaded_timestamp": "...",
+                  "file_size_bytes": 0,
+                  "md5_hash": "...",
+                  "artifact_category": "Assay Artifact from CIMAC",
+                  "data_format": "FASTQ.GZ"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/tests/data/schemas/a.json
+++ b/tests/data/schemas/a.json
@@ -1,8 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "nested_arrays": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/nested_arrays" }
+    }
+  },
   "properties": {
     "a_prop": {
       "$ref": "b.json#properties"
+    },
+    "recursive_prop": {
+      "$ref": "#/definitions/nested_arrays"
     }
   }
 }

--- a/tests/data/schemas/a.json
+++ b/tests/data/schemas/a.json
@@ -1,17 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
-    "nested_arrays": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/nested_arrays" }
-    }
-  },
+  "$id": "a.json",
+  "additionalProperties": false,
+  "type": "object",
   "properties": {
     "a_prop": {
-      "$ref": "b.json#properties"
-    },
-    "recursive_prop": {
-      "$ref": "#/definitions/nested_arrays"
+      "$ref": "b.json"
     }
   }
 }

--- a/tests/data/schemas/b.json
+++ b/tests/data/schemas/b.json
@@ -1,8 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "b.json",
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "nested_arrays": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/nested_arrays" }
+    }
+  },
   "properties": {
     "b_prop": {
-      "$ref": "c.json#properties"
+      "$ref": "c.json"
+    },
+    "recursive_prop": {
+      "$ref": "#/definitions/nested_arrays"
     }
   }
 }

--- a/tests/data/schemas/c.json
+++ b/tests/data/schemas/c.json
@@ -1,8 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "c.json",
+  "additionalProperties": false,
+  "type": "object",
   "properties": {
-    "c_prop": {
-      "type": "string"
-    }
+    "c_prop": { "type": "string" }
   }
 }

--- a/tests/test_clinicaltrial_examples.py
+++ b/tests/test_clinicaltrial_examples.py
@@ -26,18 +26,19 @@ def example_paths():
 
 
 def _fetch_validator():
-
     schema_root = SCHEMA_DIR
     schema_path = os.path.join(SCHEMA_DIR, "clinical_trial.json")
-    schema = load_and_validate_schema(schema_path, schema_root)
+    validator = load_and_validate_schema(
+        schema_path, schema_root, return_validator=True
+    )
 
-    # create validator assert schemas are valid.
-    return jsonschema.Draft7Validator(schema)
+    return validator
 
 
 @pytest.mark.parametrize("example_path", example_paths(), ids=lambda x: x[1])
 def test_schema(example_path):
     validator = _fetch_validator()
+    print(validator.resolver)
 
     full_path = os.path.join(*example_path)
     root, fname = example_path

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -163,9 +163,12 @@ def test_resolve_refs():
     b = do_resolve("b.json")
     assert b["properties"] == {"b_prop": {"c_prop": {"type": "string"}}}
 
-    # Two levels of nesting
+    # Two levels of nesting with a local ref that should *not* have been resolved
     a = do_resolve("a.json")
-    assert a["properties"] == {"a_prop": b["properties"]}
+    assert a["properties"] == {
+        "a_prop": b["properties"],
+        "recursive_prop": {"$ref": "#/definitions/nested_arrays"},
+    }
 
     # Two levels of nesting across different directories
     one = do_resolve("1.json")

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -151,11 +151,9 @@ def test_trial_core():
 
 
 def do_resolve(schema_path):
-    base_uri = f"file://{TEST_SCHEMA_DIR}/"
-
     with open(os.path.join(TEST_SCHEMA_DIR, schema_path)) as f:
         spec = json.load(f)
-        return _resolve_refs(base_uri, spec, schema_path)
+        return _resolve_refs(TEST_SCHEMA_DIR, spec, schema_path)
 
 
 def test_resolve_refs():

--- a/tests/test_trial_core.py
+++ b/tests/test_trial_core.py
@@ -24,10 +24,11 @@ def _fetch_validator(name):
 
     schema_root = SCHEMA_DIR
     schema_path = os.path.join(SCHEMA_DIR, "%s.json" % name)
-    schema = load_and_validate_schema(schema_path, schema_root)
+    validator = load_and_validate_schema(
+        schema_path, schema_root, return_validator=True
+    )
 
-    # create validator assert schemas are valid.
-    return jsonschema.Draft7Validator(schema)
+    return validator
 
 
 def _sim_olink():

--- a/tests/test_unprism.py
+++ b/tests/test_unprism.py
@@ -76,9 +76,12 @@ def test_derive_files_shipping_manifest(ct, upload_type):
             data=(
                 f"cimac_id,parent_sample_id,collection_event_name,sample_location,type_of_sample,type_of_primary_container,sample_volume_units,material_used,material_remaining,quality_of_sample,{PROTOCOL_ID_FIELD_NAME},participants.cimac_participant_id\n"
                 "CTTTPP1S1.00,SA.1.1,Baseline,---,Other,Other,Other,1,0,Other,10021,CTTTPP1\n"
+                "CTTTPP1S1.01,SA.1.1,Baseline,---,Other,Other,Other,1,0,Other,10021,CTTTPP1\n"
                 "CTTTPP1S2.00,SA.1.2,Baseline,---,Other,Other,Other,1,0,Other,10021,CTTTPP1\n"
                 "CTTTPP2S1.00,SA.2.1,Baseline,---,Other,Other,Other,1,0,Other,10021,CTTTPP2\n"
+                "CTTTPP2S1.01,SA.2.1,Baseline,---,Other,Other,Other,1,0,Other,10021,CTTTPP2\n"
                 "CTTTPP2S2.00,SA.2.2,Baseline,---,Other,Other,Other,1,0,Other,10021,CTTTPP2\n"
+                "CTTTPP2S2.01,SA.2.2,Baseline,---,Other,Other,Other,1,0,Other,10021,CTTTPP2\n"
             ),
             metadata=None,
         ),


### PR DESCRIPTION
Model each collection event as a tree of "root" and "derivative" biospecimens expected to be collected during those events - see `collection_events.json` for the new schema. Since the schema for a tree data structure is recursive, this required updating our custom schema loading logic to not resolve local refs (e.g., `#/definitions/foo`), and to return a validator with a local file ref resolver.