### PR TITLE
Fix instance name

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.24"
+__version__ = "0.16.25"

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.25"
+__version__ = "0.16.26"

--- a/cidc_schemas/pipeline_configs/wes_analysis_config.yaml.j2
+++ b/cidc_schemas/pipeline_configs/wes_analysis_config.yaml.j2
@@ -46,7 +46,7 @@ metasheet:
     normal: {{normal_sample.cimac_id}}
 
 # unique instance name
-instance_name: "{{run_id}}"
+instance_name: "{{run_id|lower|replace(".", "-")}}"
 # NOTE: "wes-auto" will automatically be prepended to this string
 
 # Number of cores for the wes instance

--- a/cidc_schemas/pipeline_configs/wes_analysis_config.yaml.j2
+++ b/cidc_schemas/pipeline_configs/wes_analysis_config.yaml.j2
@@ -46,7 +46,7 @@ metasheet:
     normal: {{normal_sample.cimac_id}}
 
 # unique instance name
-instance_name: "{{run_id|lower|replace(".", "-")}}"
+instance_name: "{{ run_id | lower | replace('.', '-') }}"
 # NOTE: "wes-auto" will automatically be prepended to this string
 
 # Number of cores for the wes instance

--- a/tests/prism/test_pipelines.py
+++ b/tests/prism/test_pipelines.py
@@ -122,7 +122,9 @@ def test_WES_pipeline_config_generation_after_prismify(prismify_result, template
         conf = yaml.load(conf)
 
         assert len(conf["metasheet"]) == 1  # one run
-
+        assert (
+            conf["instance_name"] == "ctttpp111-00"
+        )  # run ID but lowercase & hyphenated
         assert len(conf["samples"]) == 2  # tumor and normal
         for sample in conf["samples"].values():
             assert len(sample) > 0  # at lease one data file per sample


### PR DESCRIPTION
This PR corrects the instance name nomenclature in pipeline config generation to conform with Google Instance name [requirements](https://cloud.google.com/compute/docs/labeling-resources) (instances can only contain lower-case letters, numeric characters, underscores and hyphens)