### PR TITLE
Remove enum validations for collection event and cohort name

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.26"
+__version__ = "0.17.0"

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.24"
+__version__ = "0.16.25"

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.16.25"
+__version__ = "0.16.26"

--- a/cidc_schemas/metaschema/strict_meta_schema.json
+++ b/cidc_schemas/metaschema/strict_meta_schema.json
@@ -1,203 +1,220 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "strict_meta_schema",
-    "title": "Strict meta-schema",
-    "type": ["object", "boolean"],
-    "oneOf": [
-        {"required": ["$ref"]},
-        {"required": ["const"]},
-        {
-            "not": {
-                "$comment": "this makes additionalProperties or inheritableBase required only for object-describing schemas",
-                "anyOf": [
-                    {
-                        "properties": {
-                            "type": {
-                                "const": "object" 
-                            }
-                       }
-                    },
-                    {"required": ["properties"]}
-                ]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "strict_meta_schema",
+  "title": "Strict meta-schema",
+  "type": ["object", "boolean"],
+  "oneOf": [
+    { "required": ["$ref"] },
+    { "required": ["const"] },
+    {
+      "not": {
+        "$comment": "this makes additionalProperties or inheritableBase required only for object-describing schemas",
+        "anyOf": [
+          {
+            "properties": {
+              "type": {
+                "const": "object"
+              }
             }
-        },
-        {
-            "type": "object",
-            "required": ["additionalProperties"],
-            "not": {
-                "required": ["inheritableBase"],
-                "$comment": "'not' disallows matching this, making additionalProperties and inheritableBase mutually exclusive"
-            }
-        },
-        {
-            "type": "object",
-            "not": {
-                "required": ["additionalProperties"],
-                "$comment": "'not' disallows matching this, making additionalProperties and inheritableBase mutually exclusive"
-            },
-            "required": ["inheritableBase"]
-        }
-    ],
-    "properties": {
-        "additionalProperties": {
-            "$comment": "overrides draft-07 definition",
-            "const": false
-        },
-        "inheritableBase": {
-            "$comment": "Shows that a schema is an extensible 'abstract base' to inherit from and doesn't have `additionalProperties` set to false. No end user objects should be of that schema, only of something 'descendant' from it.",
-            "const": true
-        },                
-        "example": {
-            "type": "string"
-        },
-        "in_doc_ref_pattern": {
-            "$comment": "used in prism custom validator for in doc refs integrity",
-            "type": "string"
-        },
-        "enum_comments": {
-            "$comment": "used in template_writer to write excel comments",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
+          },
+          { "required": ["properties"] }
+        ]
+      }
+    },
+    {
+      "type": "object",
+      "required": ["additionalProperties"],
+      "not": {
+        "required": ["inheritableBase"],
+        "$comment": "'not' disallows matching this, making additionalProperties and inheritableBase mutually exclusive"
+      }
+    },
+    {
+      "type": "object",
+      "not": {
+        "required": ["additionalProperties"],
+        "$comment": "'not' disallows matching this, making additionalProperties and inheritableBase mutually exclusive"
+      },
+      "required": ["inheritableBase"]
+    }
+  ],
+  "properties": {
+    "additionalProperties": {
+      "$comment": "overrides draft-07 definition",
+      "const": false
+    },
+    "inheritableBase": {
+      "$comment": "Shows that a schema is an extensible 'abstract base' to inherit from and doesn't have `additionalProperties` set to false. No end user objects should be of that schema, only of something 'descendant' from it.",
+      "const": true
+    },
+    "example": {
+      "type": "string"
+    },
+    "in_doc_ref_pattern": {
+      "$comment": "used in prism custom validator for in doc refs integrity",
+      "type": "string"
+    },
 
-        "mergeStrategy": {"$comment": "jsonmerge specific"},
-        "mergeOptions": {"$comment": "jsonmerge specific"},
+    "mergeStrategy": { "$comment": "jsonmerge specific" },
+    "mergeOptions": { "$comment": "jsonmerge specific" },
 
-        "$schema": {
-            "$comment": "overrides draft-07 definition to point to this strict schema",
-            "const": "metaschema/strict_meta_schema.json#"
-        },
-        "additionalItems": { 
-            "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
-            "$ref": "#" 
-        },
-        "items": {
-            "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
-            "$ref": "#"
-        },
-        "definitions": {
-            "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
-            "additionalProperties": {"$ref": "#" } 
-        },
-        "properties": {
-            "type": "object",
-            "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
-            "additionalProperties": {"$ref": "#" } 
-        },
-        "patternProperties": false,
-        "dependencies": {
-            "type": "object",
-            "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
-            "additionalProperties": {
-                "anyOf": [
-                    { "$ref": "#" },
-                    { "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray" }
-                ]
-            }
-        },
-
-
-        "$id": {
-            "type": "string",
-            "format": "uri-reference"
-        },
-        "$schema": {
-            "type": "string",
-            "format": "uri"
-        },
-        "$ref": {
-            "type": "string",
-            "format": "uri-reference"
-        },
-        "$comment": {
-            "type": "string"
-        },
-        "title": {
-            "type": "string"
-        },
-        "description": {
-            "type": "string"
-        },
-        "default": true,
-        "readOnly": {
-            "type": "boolean",
-            "default": false
-        },
-        "examples": {
-            "type": "array",
-            "items": true
-        },
-        "multipleOf": {
-            "type": "number",
-            "exclusiveMinimum": 0
-        },
-        "maximum": {
-            "type": "number"
-        },
-        "exclusiveMaximum": {
-            "type": "number"
-        },
-        "minimum": {
-            "type": "number"
-        },
-        "exclusiveMinimum": {
-            "type": "number"
-        },
-        "maxLength": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger" },
-        "minLength": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0" },
-        "pattern": {
-            "type": "string",
-            "format": "regex"
-        },
-        "maxItems": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger" },
-        "minItems": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0" },
-        "uniqueItems": {
-            "type": "boolean",
-            "default": false
-        },
-        "contains": { "$ref": "#" },
-        "maxProperties": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger" },
-        "minProperties": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0" },
-        "required": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray" },
-        "propertyNames": { "$ref": "#" },
-        "const": true,
-        "enum": {
-            "type": "array",
-            "items": true
-        },
-        "type": {
-            "anyOf": [
-                { "$ref": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes" },
-                {
-                    "type": "array",
-                    "items": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes" },
-                    "minItems": 1,
-                    "uniqueItems": true
-                }
-            ]
-        },
-        "format": { "type": "string" },
-        "contentMediaType": { "type": "string" },
-        "contentEncoding": { "type": "string" },
-        
-        "if": {"$ref": "http://json-schema.org/draft-07/schema#"},
-        "then": {"$ref": "http://json-schema.org/draft-07/schema#"},
-        "else": {"$ref": "http://json-schema.org/draft-07/schema#"},
-        "allOf": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray" },
-        "anyOf": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray" },
-        "oneOf": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray" },
-        "not": { "$ref": "http://json-schema.org/draft-07/schema#" }
+    "$schema": {
+      "$comment": "overrides draft-07 definition to point to this strict schema",
+      "const": "metaschema/strict_meta_schema.json#"
+    },
+    "additionalItems": {
+      "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
+      "$ref": "#"
+    },
+    "items": {
+      "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
+      "$ref": "#"
     },
     "definitions": {
-        "schemaArray": {
-            "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
-            "type": "array",
-            "minItems": 1,
-            "items": { "$ref": "#" }
-        }
+      "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
+      "additionalProperties": { "$ref": "#" }
     },
-    "additionalProperties": false
+    "properties": {
+      "type": "object",
+      "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
+      "additionalProperties": { "$ref": "#" }
+    },
+    "patternProperties": false,
+    "dependencies": {
+      "type": "object",
+      "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
+      "additionalProperties": {
+        "anyOf": [
+          { "$ref": "#" },
+          {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+          }
+        ]
+      }
+    },
+
+    "$id": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "$ref": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "$comment": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": true,
+    "readOnly": {
+      "type": "boolean",
+      "default": false
+    },
+    "examples": {
+      "type": "array",
+      "items": true
+    },
+    "multipleOf": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "maximum": {
+      "type": "number"
+    },
+    "exclusiveMaximum": {
+      "type": "number"
+    },
+    "minimum": {
+      "type": "number"
+    },
+    "exclusiveMinimum": {
+      "type": "number"
+    },
+    "maxLength": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+    },
+    "minLength": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+    },
+    "pattern": {
+      "type": "string",
+      "format": "regex"
+    },
+    "maxItems": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+    },
+    "minItems": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+    },
+    "uniqueItems": {
+      "type": "boolean",
+      "default": false
+    },
+    "contains": { "$ref": "#" },
+    "maxProperties": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+    },
+    "minProperties": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+    },
+    "required": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+    },
+    "propertyNames": { "$ref": "#" },
+    "const": true,
+    "enum": {
+      "type": "array",
+      "items": true
+    },
+    "type": {
+      "anyOf": [
+        {
+          "$ref": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    },
+    "format": { "type": "string" },
+    "contentMediaType": { "type": "string" },
+    "contentEncoding": { "type": "string" },
+
+    "if": { "$ref": "http://json-schema.org/draft-07/schema#" },
+    "then": { "$ref": "http://json-schema.org/draft-07/schema#" },
+    "else": { "$ref": "http://json-schema.org/draft-07/schema#" },
+    "allOf": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray"
+    },
+    "anyOf": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray"
+    },
+    "oneOf": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray"
+    },
+    "not": { "$ref": "http://json-schema.org/draft-07/schema#" }
+  },
+  "definitions": {
+    "schemaArray": {
+      "$comment": "overrides draft-07 definition to make self ref link point to this strict schema",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#" }
+    }
+  },
+  "additionalProperties": false
 }
-  

--- a/cidc_schemas/schemas/participant.json
+++ b/cidc_schemas/schemas/participant.json
@@ -31,70 +31,7 @@
       "description": "Categorical description of cohorts, arms, and treatment groups.",
       "example": "Arm_Z",
       "in_doc_ref_pattern": "/allowed_cohort_names/*",
-      "$comment": "This enum lists a union of all possible values from all supported trials at the moment. Options are further limited by `in_doc_ref_pattern`.",
-      "enum": [
-        "Arm_A",
-        "Arm_B",
-        "Arm_C",
-        "Arm_D",
-        "Arm_E",
-        "Arm_F",
-        "Arm_G",
-        "Arm_H",
-        "Arm_I",
-        "Arm_X",
-        "Arm_Y",
-        "Arm_Z",
-
-        "Arm_1",
-        "Arm_2",
-
-        "EAY131-Z1D",
-
-        "NSCLC_A",
-        "NSCLC_B",
-        "NSCLC_C",
-        "CRC_A",
-        "CRC_B",
-
-        "Dose_A",
-        "Dose_B",
-        "Dose_C",
-        "Dose_D",
-
-        "Other",
-        "Not_reported"
-      ],
-      "enum_comments": {
-        "Arm_A": "E4412 or 10026",
-        "Arm_B": "E4412 or 10026",
-        "Arm_C": "E4412",
-        "Arm_D": "E4412",
-        "Arm_E": "E4412",
-        "Arm_F": "E4412",
-        "Arm_G": "E4412",
-        "Arm_H": "E4412",
-        "Arm_I": "E4412",
-        "Arm_X": "E4412",
-        "Arm_Y": "E4412",
-        "Arm_Z": "E4412",
-
-        "Arm_1": "S1400I",
-        "Arm_2": "S1400I",
-
-        "NSCLC_A": "10021",
-        "NSCLC_B": "10021",
-        "NSCLC_C": "10021",
-        "CRC_A": "10021",
-        "CRC_B": "10021",
-
-        "Dose_A": "9204",
-        "Dose_B": "9204",
-        "Dose_C": "9204",
-        "Dose_D": "9204",
-
-        "Not reported": "Can be used for blinded values"
-      }
+      "$comment": "Values in this field are validated dynamically by `in_doc_ref_pattern`."
     },
     "essential_patient_entry_number": {
       "description": "Provides a numbered identifier for patient (sample) entry in a shipment manifest.",

--- a/cidc_schemas/schemas/sample.json
+++ b/cidc_schemas/schemas/sample.json
@@ -428,10 +428,6 @@
                 "Not Reported",
                 "Other"
             ]
-        },
-        "intended_assay": {
-            "type": "string",
-            "description": "The assay that this sample is expected to be used as input for."
         }
     },
 

--- a/cidc_schemas/schemas/sample.json
+++ b/cidc_schemas/schemas/sample.json
@@ -496,6 +496,10 @@
                 "Not Reported",
                 "Other"
             ]
+        },
+        "intended_assay": {
+            "type": "string",
+            "description": "The assay that this sample is expected to be used as input for."
         }
     },
 

--- a/cidc_schemas/schemas/sample.json
+++ b/cidc_schemas/schemas/sample.json
@@ -69,75 +69,7 @@
             "description": "Categorical description of timepoint at which the sample was taken.",
             "type": "string",
             "in_doc_ref_pattern": "/allowed_collection_event_names/*",
-            "$comment": "This enum lists a union of all possible values from all supported trials at the moment. Options are further limited by `in_doc_ref_pattern`.",
-            "enum": [
-                "Baseline",
-                
-                "Pre_Day_1_Cycle_2",
-                "Restaging",
-                "Off_study",
-                
-                "Cycle_2_Week_3",
-                "Cycle_4_Week_7",
-                "Cycle_5_Week_9",
-
-                "Cycle_3",
-                "End_of_treatment",
-
-                "Pre_PD1_therapy",
-                "On_Treatment",
-                "Week_5",
-                "Week_7",
-
-                "Response",
-                "Relapse",
-                "Day_8",
-                "Cycle_2_Day_1",
-
-                "T0",
-                "T1",
-                "T2",
-                "T3",
-                "T4",
-                "T5",
-                "T6",
-                "End_of_Treatment",
-                "Progression",
-                
-                "Other",
-                "Not_reported"
-            ],
-            "enum_comments": {
-                "Pre_Day_1_Cycle_2": "E4412",
-                "Restaging": "E4412",
-                "Off_study": "E4412",
-                
-                "Cycle_2_Week_3": "S1400I",
-                "Cycle_4_Week_7": "S1400I",
-                "Cycle_5_Week_9": "S1400I",
-                "Progression": "S1400I, 10021",
-
-                "Cycle_3": "EAY131-Z1D",
-                "End_of_treatment": "EAY131-Z1D, 10026",
-
-                "Response": "9204",
-                "Relapse": "9204",
-                "Day_8": "9204",
-                "Cycle_2_Day_1": "9204",
-
-                "T0": "10026",
-                "T1": "10026",
-                "T2": "10026",
-                "T3": "10026",
-                "T4": "10026",
-                "T5": "10026",
-                "T6": "10026",
-
-                "Pre_PD1_therapy" : "10021",
-                "On_Treatment" : "10021",
-                "Week_5": "10021",
-                "Week_7": "10021"
-            }
+            "$comment": "Values in this field are validated dynamically by `in_doc_ref_pattern`."
         },
         "sample_location": {
             "description": "Sample location within the shipping container. Example: A1.",

--- a/cidc_schemas/template_writer.py
+++ b/cidc_schemas/template_writer.py
@@ -219,15 +219,6 @@ class XlTemplateWriter:
         if not len(enum):
             raise Exception(f"Enum {name} with no options detected:\n{prop_schema}")
 
-        comments = prop_schema.get("enum_comments", {})
-
-        for i, enum_value in enumerate(enum):
-            ws.write(1 + i, col_n, enum_value)
-            if comments and enum_value in comments and comments[enum_value]:
-                ws.write_comment(
-                    1 + i, col_n, comments[enum_value], XlThemes.COMMENT_THEME
-                )
-
         return len(enum)
 
     def _write_legend(self, schemas):

--- a/tests/test_strict_meta_schema.py
+++ b/tests/test_strict_meta_schema.py
@@ -27,13 +27,7 @@ def test_valid_simple_schema():
 
 
 def test_valid_custom_prism_keywords_schema():
-    check_valid(
-        {
-            "type": "string",
-            "in_doc_ref_pattern": "whatever",
-            "enum_comments": {"something": "else"},
-        }
-    )
+    check_valid({"type": "string", "in_doc_ref_pattern": "whatever"})
 
 
 def test_valid_base_schema():


### PR DESCRIPTION
Values in these fields will still be validated dynamically using `allowed_cohort_names` and `allowed_collection_event_names`.