### PR TITLE
Remove XHLA from RNA analysis

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
@@ -235,13 +235,6 @@
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/optitype_result.tsv",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'analysis/xhla/{id}/{id}_report-{id}-hla.json'",
-                                    "merge_pointer": "/tumor/optitype/xhla_report_hla",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/xhla_report_hla.json",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
                                 }
                             ]
                         },
@@ -330,13 +323,6 @@
                                     "parse_through": "lambda id: f'analysis/optitype/{id}/{id}_result.tsv'",
                                     "merge_pointer": "/normal/optitype/optitype_result",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/optitype_result.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                 {
-                                    "parse_through": "lambda id: f'analysis/xhla/{id}/{id}_report-{id}-hla.json'",
-                                    "merge_pointer": "/normal/optitype/xhla_report_hla",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/xhla_report_hla.json",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }

--- a/tests/prism/cidc_test_data/analysis_data.py
+++ b/tests/prism/cidc_test_data/analysis_data.py
@@ -136,10 +136,7 @@ def wes_analysis() -> PrismTestData:
                             "optitype": {
                                 "optitype_result": {
                                     "upload_placeholder": "a5899d73-7373-4041-85f9-6cc4324be817"
-                                },
-                                "xhla_report_hla": {
-                                    "upload_placeholder": "2f3307bd-960e-4735-b831-f93d20fe8d37"
-                                },
+                                }
                             },
                         },
                         "report": {
@@ -189,10 +186,7 @@ def wes_analysis() -> PrismTestData:
                             "optitype": {
                                 "optitype_result": {
                                     "upload_placeholder": "6b36da9d-c015-42be-80df-d22c17a29124"
-                                },
-                                "xhla_report_hla": {
-                                    "upload_placeholder": "f6a76030-cf27-41e6-8836-17c99479001e"
-                                },
+                                }
                             },
                         },
                     },
@@ -305,10 +299,7 @@ def wes_analysis() -> PrismTestData:
                             "optitype": {
                                 "optitype_result": {
                                     "upload_placeholder": "671d710e-f245-4d2b-8732-2774e26aec10"
-                                },
-                                "xhla_report_hla": {
-                                    "upload_placeholder": "4807aaa5-bafa-4fe5-89e9-73f9d734b971"
-                                },
+                                }
                             },
                         },
                         "report": {
@@ -358,10 +349,7 @@ def wes_analysis() -> PrismTestData:
                             "optitype": {
                                 "optitype_result": {
                                     "upload_placeholder": "9371d710-e3d0-4d1b-b87f-23bbadc4ae7e"
-                                },
-                                "xhla_report_hla": {
-                                    "upload_placeholder": "1d0c1f42-6a58-4e4b-b127-208c33f2aeb6"
-                                },
+                                }
                             },
                         },
                     },
@@ -552,12 +540,6 @@ def wes_analysis() -> PrismTestData:
             metadata_availability=None,
         ),
         LocalFileUploadEntry(
-            local_path="analysis/xhla/CTTTPP111.00/CTTTPP111.00_report-CTTTPP111.00-hla.json",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/xhla_report_hla.json",
-            upload_placeholder="2f3307bd-960e-4735-b831-f93d20fe8d37",
-            metadata_availability=None,
-        ),
-        LocalFileUploadEntry(
             local_path="analysis/align/CTTTPP111.00/CTTTPP111.00_recalibrated.bam",
             gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/recalibrated.bam",
             upload_placeholder="c4a6b91b-7ff2-4fe2-b717-1df35eb78c27",
@@ -627,12 +609,6 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/optitype/CTTTPP111.00/CTTTPP111.00_result.tsv",
             gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/optitype_result.tsv",
             upload_placeholder="6b36da9d-c015-42be-80df-d22c17a29124",
-            metadata_availability=None,
-        ),
-        LocalFileUploadEntry(
-            local_path="analysis/xhla/CTTTPP111.00/CTTTPP111.00_report-CTTTPP111.00-hla.json",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/xhla_report_hla.json",
-            upload_placeholder="f6a76030-cf27-41e6-8836-17c99479001e",
             metadata_availability=None,
         ),
         LocalFileUploadEntry(
@@ -816,12 +792,6 @@ def wes_analysis() -> PrismTestData:
             metadata_availability=None,
         ),
         LocalFileUploadEntry(
-            local_path="analysis/xhla/CTTTPP121.00/CTTTPP121.00_report-CTTTPP121.00-hla.json",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/xhla_report_hla.json",
-            upload_placeholder="4807aaa5-bafa-4fe5-89e9-73f9d734b971",
-            metadata_availability=None,
-        ),
-        LocalFileUploadEntry(
             local_path="analysis/align/CTTTPP121.00/CTTTPP121.00_recalibrated.bam",
             gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/recalibrated.bam",
             upload_placeholder="d7ef5d2c-f2e8-469c-8666-c246ad74cf8b",
@@ -891,12 +861,6 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/optitype/CTTTPP121.00/CTTTPP121.00_result.tsv",
             gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/optitype_result.tsv",
             upload_placeholder="9371d710-e3d0-4d1b-b87f-23bbadc4ae7e",
-            metadata_availability=None,
-        ),
-        LocalFileUploadEntry(
-            local_path="analysis/xhla/CTTTPP121.00/CTTTPP121.00_report-CTTTPP121.00-hla.json",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/xhla_report_hla.json",
-            upload_placeholder="1d0c1f42-6a58-4e4b-b127-208c33f2aeb6",
             metadata_availability=None,
         ),
     ]


### PR DESCRIPTION
Removed XHLA files from RNA analysis expected outputs. 

XHLA is only produced when Neoantigen Class 2 is run, which is not the case in the current state of the pipeline. 
( Goes with #309 )