### PR TITLE
one rnaseq pipeline config for all participants

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/tests/prism/test_pipelines.py
+++ b/tests/prism/test_pipelines.py
@@ -140,13 +140,7 @@ def test_RNAseq_pipeline_config_generation_after_prismify(prismify_result, templ
         return
 
     full_ct = get_test_trial(
-        [
-            "CTTTPP111.00",
-            "CTTTPP122.00",
-            "CTTTPP123.00",
-            "CTTTPP221.00",
-            "CTTTPP222.00",
-        ],
+        ["CTTTPP111.00", "CTTTPP121.00", "CTTTPP122.00", "CTTTPP123.00"],
         assays={"rna": []},
     )
 

--- a/tests/prism/test_pipelines.py
+++ b/tests/prism/test_pipelines.py
@@ -142,10 +142,10 @@ def test_RNAseq_pipeline_config_generation_after_prismify(prismify_result, templ
     full_ct = get_test_trial(
         [
             "CTTTPP111.00",
-            "CTTTPP121.00",
             "CTTTPP122.00",
-            "CTTTPP121.00",
             "CTTTPP123.00",
+            "CTTTPP221.00",
+            "CTTTPP222.00",
         ],
         assays={"rna": []},
     )


### PR DESCRIPTION
removes rendering multiple per participant pipeline configs in favor of one combined