### PR TITLE
Add back accidentally deleted code to data dictionary writer

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.18.2"
+__version__ = "0.18.3"

--- a/cidc_schemas/template_writer.py
+++ b/cidc_schemas/template_writer.py
@@ -214,7 +214,12 @@ class XlTemplateWriter:
         if not enum:
             return 0
 
+        # Write the data dict column header
         ws.write(0, col_n, name.capitalize(), theme)
+
+        # Write the data dict column values
+        for i, enum_value in enumerate(enum):
+            ws.write(1 + i, col_n, enum_value)
 
         if not len(enum):
             raise Exception(f"Enum {name} with no options detected:\n{prop_schema}")


### PR DESCRIPTION
whoops: https://github.com/CIMAC-CIDC/cidc-schemas/commit/2d803c5b508d7cbab6d15330e55ade635abcd6c2#diff-b9ebd0ac856744847315becc435e8ece

The above change broke template dropdowns.