### PR TITLE
Better messaging for merge collision errors with local object context

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.18.3"
+__version__ = "0.18.4"

--- a/cidc_schemas/prism/merger.py
+++ b/cidc_schemas/prism/merger.py
@@ -194,7 +194,7 @@ class ThrowOnOverwrite(strategies.Strategy):
         if base.val != head.val:
             obj_pointer, _, prop_name = base.ref.rpartition("/")
             raise MergeCollisionException(
-                f"Found mismatch of incoming value {prop_name}={base.val!r} with already saved {prop_name}={head.val!r} "
+                f"Found mismatch of incoming {prop_name}={base.val!r} with already saved {prop_name}={head.val!r} "
                 f"{obj_pointer.lstrip('#/')}",
                 base,
                 head,

--- a/cidc_schemas/prism/merger.py
+++ b/cidc_schemas/prism/merger.py
@@ -192,10 +192,9 @@ class ThrowOnOverwrite(strategies.Strategy):
         if base.is_undef():
             return head
         if base.val != head.val:
-            obj_pointer, _, prop_name = base.ref.rpartition("/")
+            _, prop_name = base.ref.rsplit("/", 1)
             raise MergeCollisionException(
-                f"Found mismatch of incoming {prop_name}={base.val!r} with already saved {prop_name}={head.val!r} "
-                f"{obj_pointer.lstrip('#/')}",
+                f"Found mismatch of incoming {prop_name}={head.val!r} with already saved {prop_name}={base.val!r}",
                 base,
                 head,
             )
@@ -212,8 +211,9 @@ class ArrayMergeByIdWithContextForMergeCollisionException(strategies.ArrayMergeB
         except MergeCollisionException as merge_e:
             try:
                 key = self.get_key(walk, merge_e.head, idRef)
+                _, prop_name = base.ref.rsplit("/", 1)
                 raise MergeCollisionException(
-                    f"{merge_e} {idRef.lstrip('/')}={key}", base, head
+                    f"{merge_e} in {prop_name}/{idRef.lstrip('/')}={key}", base, head
                 ) from merge_e
             except jsonschema.exceptions.RefResolutionError as ref_e:
                 raise merge_e

--- a/tests/prism/test_merger.py
+++ b/tests/prism/test_merger.py
@@ -27,12 +27,9 @@ def test_throw_on_mismatch():
         "properties": {
             "participants": {
                 "type": "array",
-                "items": {
-                    "cimac_id": {"type": "string"},
-                    "weight": {"type": "integer"},
-                },
+                "items": {"p_id": {"type": "string"}, "weight": {"type": "integer"}},
                 "mergeStrategy": "arrayMergeById",
-                "mergeOptions": {"idRef": "/cimac_id"},
+                "mergeOptions": {"idRef": "/p_id"},
             }
         },
     }
@@ -40,30 +37,22 @@ def test_throw_on_mismatch():
     merger = Merger(schema, strategies=prism_merger.PRISM_MERGE_STRATEGIES)
 
     # Identical values, no mismatch - no error
-    base = {
-        "participants": [
-            {"cimac_id": "c1", "weight": 1},
-            {"cimac_id": "c2", "weight": 2},
-        ]
-    }
+    base = {"participants": [{"p_id": "c1", "weight": 1}, {"p_id": "c2", "weight": 2}]}
     assert merger.merge(base, base)
 
     # Different values, mismatch - error
     head = {
-        "participants": [
-            {"cimac_id": "c2", "weight": 333},
-            {"cimac_id": "c3", "weight": 3},
-        ]
+        "participants": [{"p_id": "c2", "weight": 333}, {"p_id": "c3", "weight": 3}]
     }
     with pytest.raises(
         prism_merger.MergeCollisionException,
-        match="mismatch of incoming weight=333 with already saved weight=2 in participants/cimac_id=c2",
+        match="mismatch of incoming weight=333 with already saved weight=2 in participants/p_id=c2",
     ):
         merger.merge(base, head)
 
     # Some identical and some different values - no error, proper merge
-    base["participants"].append({"cimac_id": "c2", "weight": 2})
-    head = {"participants": [base["participants"][0], {"cimac_id": "c3", "weight": 3}]}
+    base["participants"].append({"p_id": "c2", "weight": 2})
+    head = {"participants": [base["participants"][0], {"p_id": "c3", "weight": 3}]}
 
     assert merger.merge(base, head) == {
         "participants": [*base["participants"], head["participants"][-1]]
@@ -86,12 +75,12 @@ def test_throw_on_mismatch_context():
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "cimac_id": {"type": "string"},
+                                    "sample_id": {"type": "string"},
                                     "weight": {"type": "integer"},
                                 },
                             },
                             "mergeStrategy": "arrayMergeById",
-                            "mergeOptions": {"idRef": "/cimac_id"},
+                            "mergeOptions": {"idRef": "/sample_id"},
                         },
                     },
                 },
@@ -106,7 +95,7 @@ def test_throw_on_mismatch_context():
     # Identical values, no collision - no error
     base = {
         "participants": [
-            {"participant_id": "p1", "samples": [{"cimac_id": "c1", "weight": 2}]}
+            {"participant_id": "p1", "samples": [{"sample_id": "c1", "weight": 2}]}
         ]
     }
     assert merger.merge(base, base)
@@ -114,13 +103,13 @@ def test_throw_on_mismatch_context():
     # Different values, collision - error
     head = {
         "participants": [
-            {"participant_id": "p1", "samples": [{"cimac_id": "c1", "weight": 333}]}
+            {"participant_id": "p1", "samples": [{"sample_id": "c1", "weight": 333}]}
         ]
     }
     with pytest.raises(
         prism_merger.MergeCollisionException,
         match="mismatch of incoming weight=333 with already saved weight=2"
-        " in samples/cimac_id=c1 in participants/participant_id=p1",
+        " in samples/sample_id=c1 in participants/participant_id=p1",
     ):
         merger.merge(base, head)
 

--- a/tests/prism/test_merger.py
+++ b/tests/prism/test_merger.py
@@ -37,13 +37,14 @@ def test_throw_on_collision():
     merger = Merger(schema, strategies=prism_merger.PRISM_MERGE_STRATEGIES)
 
     # Identical values, no collision - no error
-    base = {"l": [{"cimac_id": "c1", "a": 1}]}
+    base = {"l": [{"cimac_id": "c1", "a": 1}, {"cimac_id": "c2", "a": 2}]}
     assert merger.merge(base, base)
 
     # Different values, collision - error
-    head = {"l": [{"cimac_id": "c1", "a": 2}]}
+    head = {"l": [{"cimac_id": "c2", "a": 333}, {"cimac_id": "c3", "a": 3}]}
     with pytest.raises(
-        prism_merger.MergeCollisionException, match=r"1 \(current\) != 2 \(incoming\)"
+        prism_merger.MergeCollisionException,
+        match="mismatch of incoming value a=2 with already saved a=333 l/\d+ cimac_id=c2",
     ):
         merger.merge(base, head)
 
@@ -71,10 +72,11 @@ def test_overwrite_any():
     head = {"a": {"foo": "buzz"}, "b": 1}
     assert merger.merge(base, head) == head
 
-    # Updates to "b" should not be allowed
+    # Updates to "b" still should not be allowed
     head["b"] = 2
     with pytest.raises(
-        prism_merger.MergeCollisionException, match=r"1 \(current\) != 2 \(incoming\)"
+        prism_merger.MergeCollisionException,
+        match="mismatch of incoming value b=1 with already saved b=2",
     ):
         merger.merge(base, head)
 


### PR DESCRIPTION
extracted from 'arrayMergeById' strategy setting