### PR TITLE
WES versioning files

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.18.9"
+__version__ = "0.18.10"

--- a/cidc_schemas/schemas/artifacts/artifact_core.json
+++ b/cidc_schemas/schemas/artifacts/artifact_core.json
@@ -86,6 +86,7 @@
         "FCS",
         "GZ",
         "JSON",
+        "YAML",
         "[NOT SET]"
       ]
     }

--- a/cidc_schemas/schemas/artifacts/artifact_yaml.json
+++ b/cidc_schemas/schemas/artifacts/artifact_yaml.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "metaschema/strict_meta_schema.json#",
+  "$id": "yaml_artifact",
+  "title": "YAML Artifact",
+  "type": "object",
+  "description": "Information about a YAML file.",
+  "additionalProperties": false,
+  "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "YAML"
+    },
+    "upload_placeholder": {"$ref": "artifacts/artifact_core.json#properties/upload_placeholder"},
+    "artifact_creator": {"$ref": "artifacts/artifact_core.json#properties/artifact_creator"},
+    "uploader": {"$ref": "artifacts/artifact_core.json#properties/uploader"},
+    "uuid": {"$ref": "artifacts/artifact_core.json#properties/uuid"},
+    "file_name": {"$ref": "artifacts/artifact_core.json#properties/file_name"},
+    "object_url": {"$ref": "artifacts/artifact_core.json#properties/object_url"},
+    "uploaded_timestamp": {"$ref": "artifacts/artifact_core.json#properties/uploaded_timestamp"},
+    "file_size_bytes": {"$ref": "artifacts/artifact_core.json#properties/file_size_bytes"},
+    "md5_hash": {"$ref": "artifacts/artifact_core.json#properties/md5_hash"},
+    "crc32c_hash": {"$ref": "artifacts/artifact_core.json#properties/crc32c_hash"},
+    "visible": {"$ref": "artifacts/artifact_core.json#properties/visible"},
+    "artifact_category": {"$ref": "artifacts/artifact_core.json#properties/artifact_category"}
+  },
+  "allOf": [
+    {
+      "$ref": "artifacts/artifact_core.json"
+    }
+  ],
+  "mergeStrategy": "objectMerge"
+}

--- a/cidc_schemas/schemas/assays/components/ngs/wes/report.json
+++ b/cidc_schemas/schemas/assays/components/ngs/wes/report.json
@@ -8,12 +8,16 @@
     "wes_version": {
       "$ref": "artifacts/artifact_text.json"
     },
+    "config": {
+      "$ref": "artifacts/artifact_text.json"
+    },
     "wes_run_version": {
       "$ref": "artifacts/artifact_tsv.json"
     }
   },
   "required": [
     "wes_version",
+    "config",
     "wes_run_version"
   ],
   "additionalProperties": false

--- a/cidc_schemas/schemas/assays/components/ngs/wes/report.json
+++ b/cidc_schemas/schemas/assays/components/ngs/wes/report.json
@@ -9,7 +9,7 @@
       "$ref": "artifacts/artifact_text.json"
     },
     "config": {
-      "$ref": "artifacts/artifact_text.json"
+      "$ref": "artifacts/artifact_yaml.json"
     },
     "wes_run_version": {
       "$ref": "artifacts/artifact_tsv.json"

--- a/cidc_schemas/schemas/assays/components/ngs/wes/report.json
+++ b/cidc_schemas/schemas/assays/components/ngs/wes/report.json
@@ -7,10 +7,14 @@
   "properties": {
     "wes_version": {
       "$ref": "artifacts/artifact_text.json"
+    },
+    "wes_run_version": {
+      "$ref": "artifacts/artifact_tsv.json"
     }
   },
   "required": [
-  "wes_version"
+    "wes_version",
+    "wes_run_version"
   ],
   "additionalProperties": false
 }

--- a/cidc_schemas/schemas/assays/components/ngs/wes/report.json
+++ b/cidc_schemas/schemas/assays/components/ngs/wes/report.json
@@ -13,12 +13,16 @@
     },
     "wes_run_version": {
       "$ref": "artifacts/artifact_tsv.json"
+    },
+    "metasheet": {
+      "$ref": "artifacts/artifact_csv.json"
     }
   },
   "required": [
     "wes_version",
     "config",
-    "wes_run_version"
+    "wes_run_version",
+    "metasheet"
   ],
   "additionalProperties": false
 }

--- a/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
@@ -173,6 +173,13 @@
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_run_version.tsv",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'analysis/report/metasheet.csv'",
+                                    "merge_pointer": "/report/metasheet",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/metasheet.csv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
                                 }
                             ]
                         },

--- a/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
@@ -159,6 +159,13 @@
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_version.txt",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'analysis/report/wes_meta/02_wes_run_version.tsv'",
+                                    "merge_pointer": "/report/wes_run_version",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_run_version.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
                                 }
                             ]
                         },

--- a/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
@@ -161,6 +161,13 @@
                                     "is_artifact": 1
                                 },
                                 {
+                                    "parse_through": "lambda id: f'analysis/report/config.yaml'",
+                                    "merge_pointer": "/report/config",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/config.yaml",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
                                     "parse_through": "lambda id: f'analysis/report/wes_meta/02_wes_run_version.tsv'",
                                     "merge_pointer": "/report/wes_run_version",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_run_version.tsv",

--- a/docs/docs/artifacts.artifact_bam.html
+++ b/docs/docs/artifacts.artifact_bam.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_bam_bai.html
+++ b/docs/docs/artifacts.artifact_bam_bai.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_binary.html
+++ b/docs/docs/artifacts.artifact_binary.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_core.html
+++ b/docs/docs/artifacts.artifact_core.html
@@ -557,6 +557,8 @@
                 
                     <li>"JSON"</li>
                 
+                    <li>"YAML"</li>
+                
                     <li>"[NOT SET]"</li>
                 
             </ul>
@@ -654,6 +656,7 @@
                 "FCS",
                 "GZ",
                 "JSON",
+                "YAML",
                 "[NOT SET]"
             ],
             "type": "string"

--- a/docs/docs/artifacts.artifact_csv.html
+++ b/docs/docs/artifacts.artifact_csv.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_elisa_xlsx.html
+++ b/docs/docs/artifacts.artifact_elisa_xlsx.html
@@ -577,6 +577,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_fastq_gz.html
+++ b/docs/docs/artifacts.artifact_fastq_gz.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_fcs.html
+++ b/docs/docs/artifacts.artifact_fcs.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_gz.html
+++ b/docs/docs/artifacts.artifact_gz.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_image.html
+++ b/docs/docs/artifacts.artifact_image.html
@@ -607,6 +607,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_json.html
+++ b/docs/docs/artifacts.artifact_json.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_maf.html
+++ b/docs/docs/artifacts.artifact_maf.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_npx.html
+++ b/docs/docs/artifacts.artifact_npx.html
@@ -576,6 +576,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_tbi.html
+++ b/docs/docs/artifacts.artifact_tbi.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_text.html
+++ b/docs/docs/artifacts.artifact_text.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_tsv.html
+++ b/docs/docs/artifacts.artifact_tsv.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_vcf_gz.html
+++ b/docs/docs/artifacts.artifact_vcf_gz.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_xlsx.html
+++ b/docs/docs/artifacts.artifact_xlsx.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/artifacts.artifact_yaml.html
+++ b/docs/docs/artifacts.artifact_yaml.html
@@ -31,9 +31,9 @@
         <p>
             <a href="index.html">CIDC Data Model</a>
         </p>
-        <h1>VCF Artifact</h1>
+        <h1>YAML Artifact</h1>
         <p>
-            <b>Description:</b>  Information about a VCF file.
+            <b>Description:</b>  Information about a YAML file.
         </p>
         
     </div>
@@ -128,7 +128,7 @@
     </td>
     <td>
         
-            &lt; const: <strong>VCF</strong> &gt;            
+            &lt; const: <strong>YAML</strong> &gt;            
         
     </td>
 </tr>
@@ -416,9 +416,9 @@
   </div>
 
   <div class="container">
-    <h3>artifact_vcf.full.json</h3>
+    <h3>artifact_yaml.full.json</h3>
   	<pre><code>{
-    "$id": "vcf_artifact",
+    "$id": "yaml_artifact",
     "$schema": "metaschema/strict_meta_schema.json#",
     "additionalProperties": false,
     "allOf": [
@@ -551,7 +551,7 @@
             "type": "object"
         }
     ],
-    "description": "Information about a VCF file.",
+    "description": "Information about a YAML file.",
     "mergeStrategy": "objectMerge",
     "properties": {
         "artifact_category": {
@@ -578,7 +578,7 @@
             "type": "string"
         },
         "data_format": {
-            "const": "VCF",
+            "const": "YAML",
             "description": "Data format."
         },
         "file_name": {
@@ -621,7 +621,7 @@
             "type": "boolean"
         }
     },
-    "title": "VCF Artifact",
+    "title": "YAML Artifact",
     "type": "object"
 }</code></pre>
   </container>

--- a/docs/docs/artifacts.artifact_zip.html
+++ b/docs/docs/artifacts.artifact_zip.html
@@ -502,6 +502,7 @@
                         "FCS",
                         "GZ",
                         "JSON",
+                        "YAML",
                         "[NOT SET]"
                     ],
                     "type": "string"

--- a/docs/docs/assays.components.available_assays.html
+++ b/docs/docs/assays.components.available_assays.html
@@ -503,6 +503,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -709,6 +710,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1091,6 +1093,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1297,6 +1300,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1521,6 +1525,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1727,6 +1732,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1933,6 +1939,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2139,6 +2146,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2345,6 +2353,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2551,6 +2560,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2757,6 +2767,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2995,6 +3006,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3203,6 +3215,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -3578,6 +3591,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -4034,6 +4048,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -4678,6 +4693,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -4912,6 +4928,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -5146,6 +5163,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -5398,6 +5416,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -5632,6 +5651,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -5839,6 +5859,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -6046,6 +6067,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -6281,6 +6303,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -6499,6 +6522,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -7074,6 +7098,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -7293,6 +7318,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -7527,6 +7553,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -7734,6 +7761,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -7941,6 +7969,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -8176,6 +8205,7 @@
                                                                                         "FCS",
                                                                                         "GZ",
                                                                                         "JSON",
+                                                                                        "YAML",
                                                                                         "[NOT SET]"
                                                                                     ],
                                                                                     "type": "string"
@@ -8398,6 +8428,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -8632,6 +8663,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -8866,6 +8898,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -9112,6 +9145,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9346,6 +9380,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9553,6 +9588,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9760,6 +9796,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9994,6 +10031,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -10228,6 +10266,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -10462,6 +10501,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -10701,6 +10741,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -10928,6 +10969,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -11135,6 +11177,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -11495,6 +11538,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -11731,6 +11775,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -12018,6 +12063,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -12435,6 +12481,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -12646,6 +12693,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -12857,6 +12905,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -13119,6 +13168,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13330,6 +13380,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13541,6 +13592,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13964,6 +14016,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14175,6 +14228,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14386,6 +14440,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14642,6 +14697,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -14853,6 +14909,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -15064,6 +15121,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -15289,6 +15347,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -15495,6 +15554,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -15701,6 +15761,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -15907,6 +15968,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16137,6 +16199,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16343,6 +16406,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16549,6 +16613,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16755,6 +16820,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16961,6 +17027,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17167,6 +17234,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17373,6 +17441,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17579,6 +17648,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17803,6 +17873,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -18009,6 +18080,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"

--- a/docs/docs/assays.components.available_ngs_analyses.html
+++ b/docs/docs/assays.components.available_ngs_analyses.html
@@ -234,6 +234,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -440,6 +441,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -646,6 +648,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -852,6 +855,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1058,6 +1062,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1281,6 +1286,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1487,6 +1493,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1693,6 +1700,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1899,6 +1907,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2105,6 +2114,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2311,6 +2321,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2517,6 +2528,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2723,6 +2735,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2929,6 +2942,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3135,6 +3149,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3363,6 +3378,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3569,6 +3585,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3775,6 +3792,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3981,6 +3999,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4187,6 +4206,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4443,6 +4463,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4662,6 +4683,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4868,6 +4890,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -5088,6 +5111,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -5294,6 +5318,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -5513,6 +5538,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -5732,6 +5758,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -5938,6 +5965,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -6144,6 +6172,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -6350,6 +6379,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -6578,6 +6608,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -6784,6 +6815,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -6990,6 +7022,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -7196,6 +7229,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -7426,6 +7460,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -7632,6 +7667,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -7838,6 +7874,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -8044,6 +8081,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -8250,6 +8288,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -8456,6 +8495,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -8662,6 +8702,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -8868,6 +8909,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -9092,6 +9134,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -9298,6 +9341,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -9524,6 +9568,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -9658,6 +9703,627 @@
                                 "additionalProperties": false,
                                 "description": "WES pipeline version/commit string.",
                                 "properties": {
+                                    "config": {
+                                        "$id": "yaml_artifact",
+                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                        "additionalProperties": false,
+                                        "allOf": [
+                                            {
+                                                "$id": "artifact_core",
+                                                "$schema": "metaschema/strict_meta_schema.json#",
+                                                "anyOf": [
+                                                    {
+                                                        "required": [
+                                                            "file_name",
+                                                            "object_url",
+                                                            "uploaded_timestamp",
+                                                            "file_size_bytes",
+                                                            "artifact_category",
+                                                            "data_format",
+                                                            "md5_hash"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "file_name",
+                                                            "object_url",
+                                                            "uploaded_timestamp",
+                                                            "file_size_bytes",
+                                                            "artifact_category",
+                                                            "data_format",
+                                                            "crc32c_hash"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "upload_placeholder"
+                                                        ]
+                                                    }
+                                                ],
+                                                "description": "Any file artifact associated with a clinical trial.",
+                                                "inheritableBase": true,
+                                                "properties": {
+                                                    "artifact_category": {
+                                                        "description": "Artifact category.",
+                                                        "enum": [
+                                                            "Assay Artifact from CIMAC",
+                                                            "Pipeline Artifact",
+                                                            "Manifest File"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "artifact_creator": {
+                                                        "description": "The name of the center that created this artifact.",
+                                                        "enum": [
+                                                            "DFCI",
+                                                            "Mount Sinai",
+                                                            "Stanford",
+                                                            "MD Anderson"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "crc32c_hash": {
+                                                        "description": "CRC32c Hash of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "data_format": {
+                                                        "description": "Data Format.",
+                                                        "enum": [
+                                                            "FASTA",
+                                                            "FASTQ.GZ",
+                                                            "VCF.GZ",
+                                                            "IMAGE",
+                                                            "VCF",
+                                                            "CSV",
+                                                            "TSV",
+                                                            "XLSX",
+                                                            "NPX",
+                                                            "ELISA",
+                                                            "BAM",
+                                                            "BAM.BAI",
+                                                            "MAF",
+                                                            "BINARY",
+                                                            "TEXT",
+                                                            "ZIP",
+                                                            "FCS",
+                                                            "GZ",
+                                                            "JSON",
+                                                            "YAML",
+                                                            "[NOT SET]"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "file_name": {
+                                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                        "description": "The name of the file with extension.",
+                                                        "type": "string"
+                                                    },
+                                                    "file_size_bytes": {
+                                                        "description": "File size in bytes.",
+                                                        "type": "integer"
+                                                    },
+                                                    "md5_hash": {
+                                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                        "type": "string"
+                                                    },
+                                                    "object_url": {
+                                                        "description": "URL to artifact within Google Bucket.",
+                                                        "type": "string"
+                                                    },
+                                                    "upload_placeholder": {
+                                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                                        "type": "string"
+                                                    },
+                                                    "uploaded_timestamp": {
+                                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "uploader": {
+                                                        "description": "The name of the person uploading the artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "description": "UUID of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "visible": {
+                                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "title": "Artifact Core",
+                                                "type": "object"
+                                            }
+                                        ],
+                                        "description": "Information about a YAML file.",
+                                        "mergeStrategy": "objectMerge",
+                                        "properties": {
+                                            "artifact_category": {
+                                                "description": "Artifact category.",
+                                                "enum": [
+                                                    "Assay Artifact from CIMAC",
+                                                    "Pipeline Artifact",
+                                                    "Manifest File"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "artifact_creator": {
+                                                "description": "The name of the center that created this artifact.",
+                                                "enum": [
+                                                    "DFCI",
+                                                    "Mount Sinai",
+                                                    "Stanford",
+                                                    "MD Anderson"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "crc32c_hash": {
+                                                "description": "CRC32c Hash of artifact.",
+                                                "type": "string"
+                                            },
+                                            "data_format": {
+                                                "const": "YAML",
+                                                "description": "Data format."
+                                            },
+                                            "file_name": {
+                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                "description": "The name of the file with extension.",
+                                                "type": "string"
+                                            },
+                                            "file_size_bytes": {
+                                                "description": "File size in bytes.",
+                                                "type": "integer"
+                                            },
+                                            "md5_hash": {
+                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                "type": "string"
+                                            },
+                                            "object_url": {
+                                                "description": "URL to artifact within Google Bucket.",
+                                                "type": "string"
+                                            },
+                                            "upload_placeholder": {
+                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                "type": "string"
+                                            },
+                                            "uploaded_timestamp": {
+                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "uploader": {
+                                                "description": "The name of the person uploading the artifact.",
+                                                "type": "string"
+                                            },
+                                            "uuid": {
+                                                "description": "UUID of artifact.",
+                                                "type": "string"
+                                            },
+                                            "visible": {
+                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "title": "YAML Artifact",
+                                        "type": "object"
+                                    },
+                                    "metasheet": {
+                                        "$id": "csv_artifact",
+                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                        "additionalProperties": false,
+                                        "allOf": [
+                                            {
+                                                "$id": "artifact_core",
+                                                "$schema": "metaschema/strict_meta_schema.json#",
+                                                "anyOf": [
+                                                    {
+                                                        "required": [
+                                                            "file_name",
+                                                            "object_url",
+                                                            "uploaded_timestamp",
+                                                            "file_size_bytes",
+                                                            "artifact_category",
+                                                            "data_format",
+                                                            "md5_hash"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "file_name",
+                                                            "object_url",
+                                                            "uploaded_timestamp",
+                                                            "file_size_bytes",
+                                                            "artifact_category",
+                                                            "data_format",
+                                                            "crc32c_hash"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "upload_placeholder"
+                                                        ]
+                                                    }
+                                                ],
+                                                "description": "Any file artifact associated with a clinical trial.",
+                                                "inheritableBase": true,
+                                                "properties": {
+                                                    "artifact_category": {
+                                                        "description": "Artifact category.",
+                                                        "enum": [
+                                                            "Assay Artifact from CIMAC",
+                                                            "Pipeline Artifact",
+                                                            "Manifest File"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "artifact_creator": {
+                                                        "description": "The name of the center that created this artifact.",
+                                                        "enum": [
+                                                            "DFCI",
+                                                            "Mount Sinai",
+                                                            "Stanford",
+                                                            "MD Anderson"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "crc32c_hash": {
+                                                        "description": "CRC32c Hash of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "data_format": {
+                                                        "description": "Data Format.",
+                                                        "enum": [
+                                                            "FASTA",
+                                                            "FASTQ.GZ",
+                                                            "VCF.GZ",
+                                                            "IMAGE",
+                                                            "VCF",
+                                                            "CSV",
+                                                            "TSV",
+                                                            "XLSX",
+                                                            "NPX",
+                                                            "ELISA",
+                                                            "BAM",
+                                                            "BAM.BAI",
+                                                            "MAF",
+                                                            "BINARY",
+                                                            "TEXT",
+                                                            "ZIP",
+                                                            "FCS",
+                                                            "GZ",
+                                                            "JSON",
+                                                            "YAML",
+                                                            "[NOT SET]"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "file_name": {
+                                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                        "description": "The name of the file with extension.",
+                                                        "type": "string"
+                                                    },
+                                                    "file_size_bytes": {
+                                                        "description": "File size in bytes.",
+                                                        "type": "integer"
+                                                    },
+                                                    "md5_hash": {
+                                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                        "type": "string"
+                                                    },
+                                                    "object_url": {
+                                                        "description": "URL to artifact within Google Bucket.",
+                                                        "type": "string"
+                                                    },
+                                                    "upload_placeholder": {
+                                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                                        "type": "string"
+                                                    },
+                                                    "uploaded_timestamp": {
+                                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "uploader": {
+                                                        "description": "The name of the person uploading the artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "description": "UUID of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "visible": {
+                                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "title": "Artifact Core",
+                                                "type": "object"
+                                            }
+                                        ],
+                                        "description": "Information about a comma separated file.",
+                                        "mergeStrategy": "objectMerge",
+                                        "properties": {
+                                            "artifact_category": {
+                                                "description": "Artifact category.",
+                                                "enum": [
+                                                    "Assay Artifact from CIMAC",
+                                                    "Pipeline Artifact",
+                                                    "Manifest File"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "artifact_creator": {
+                                                "description": "The name of the center that created this artifact.",
+                                                "enum": [
+                                                    "DFCI",
+                                                    "Mount Sinai",
+                                                    "Stanford",
+                                                    "MD Anderson"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "crc32c_hash": {
+                                                "description": "CRC32c Hash of artifact.",
+                                                "type": "string"
+                                            },
+                                            "data_format": {
+                                                "const": "CSV",
+                                                "description": "Data format."
+                                            },
+                                            "file_name": {
+                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                "description": "The name of the file with extension.",
+                                                "type": "string"
+                                            },
+                                            "file_size_bytes": {
+                                                "description": "File size in bytes.",
+                                                "type": "integer"
+                                            },
+                                            "md5_hash": {
+                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                "type": "string"
+                                            },
+                                            "object_url": {
+                                                "description": "URL to artifact within Google Bucket.",
+                                                "type": "string"
+                                            },
+                                            "upload_placeholder": {
+                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                "type": "string"
+                                            },
+                                            "uploaded_timestamp": {
+                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "uploader": {
+                                                "description": "The name of the person uploading the artifact.",
+                                                "type": "string"
+                                            },
+                                            "uuid": {
+                                                "description": "UUID of artifact.",
+                                                "type": "string"
+                                            },
+                                            "visible": {
+                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "title": "CSV Artifact",
+                                        "type": "object"
+                                    },
+                                    "wes_run_version": {
+                                        "$id": "tsv_artifact",
+                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                        "additionalProperties": false,
+                                        "allOf": [
+                                            {
+                                                "$id": "artifact_core",
+                                                "$schema": "metaschema/strict_meta_schema.json#",
+                                                "anyOf": [
+                                                    {
+                                                        "required": [
+                                                            "file_name",
+                                                            "object_url",
+                                                            "uploaded_timestamp",
+                                                            "file_size_bytes",
+                                                            "artifact_category",
+                                                            "data_format",
+                                                            "md5_hash"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "file_name",
+                                                            "object_url",
+                                                            "uploaded_timestamp",
+                                                            "file_size_bytes",
+                                                            "artifact_category",
+                                                            "data_format",
+                                                            "crc32c_hash"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "upload_placeholder"
+                                                        ]
+                                                    }
+                                                ],
+                                                "description": "Any file artifact associated with a clinical trial.",
+                                                "inheritableBase": true,
+                                                "properties": {
+                                                    "artifact_category": {
+                                                        "description": "Artifact category.",
+                                                        "enum": [
+                                                            "Assay Artifact from CIMAC",
+                                                            "Pipeline Artifact",
+                                                            "Manifest File"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "artifact_creator": {
+                                                        "description": "The name of the center that created this artifact.",
+                                                        "enum": [
+                                                            "DFCI",
+                                                            "Mount Sinai",
+                                                            "Stanford",
+                                                            "MD Anderson"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "crc32c_hash": {
+                                                        "description": "CRC32c Hash of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "data_format": {
+                                                        "description": "Data Format.",
+                                                        "enum": [
+                                                            "FASTA",
+                                                            "FASTQ.GZ",
+                                                            "VCF.GZ",
+                                                            "IMAGE",
+                                                            "VCF",
+                                                            "CSV",
+                                                            "TSV",
+                                                            "XLSX",
+                                                            "NPX",
+                                                            "ELISA",
+                                                            "BAM",
+                                                            "BAM.BAI",
+                                                            "MAF",
+                                                            "BINARY",
+                                                            "TEXT",
+                                                            "ZIP",
+                                                            "FCS",
+                                                            "GZ",
+                                                            "JSON",
+                                                            "YAML",
+                                                            "[NOT SET]"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "file_name": {
+                                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                        "description": "The name of the file with extension.",
+                                                        "type": "string"
+                                                    },
+                                                    "file_size_bytes": {
+                                                        "description": "File size in bytes.",
+                                                        "type": "integer"
+                                                    },
+                                                    "md5_hash": {
+                                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                        "type": "string"
+                                                    },
+                                                    "object_url": {
+                                                        "description": "URL to artifact within Google Bucket.",
+                                                        "type": "string"
+                                                    },
+                                                    "upload_placeholder": {
+                                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                                        "type": "string"
+                                                    },
+                                                    "uploaded_timestamp": {
+                                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "uploader": {
+                                                        "description": "The name of the person uploading the artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "description": "UUID of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "visible": {
+                                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "title": "Artifact Core",
+                                                "type": "object"
+                                            }
+                                        ],
+                                        "description": "Information about a tab Separated file.",
+                                        "mergeStrategy": "objectMerge",
+                                        "properties": {
+                                            "artifact_category": {
+                                                "description": "Artifact category.",
+                                                "enum": [
+                                                    "Assay Artifact from CIMAC",
+                                                    "Pipeline Artifact",
+                                                    "Manifest File"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "artifact_creator": {
+                                                "description": "The name of the center that created this artifact.",
+                                                "enum": [
+                                                    "DFCI",
+                                                    "Mount Sinai",
+                                                    "Stanford",
+                                                    "MD Anderson"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "crc32c_hash": {
+                                                "description": "CRC32c Hash of artifact.",
+                                                "type": "string"
+                                            },
+                                            "data_format": {
+                                                "const": "TSV",
+                                                "description": "Data format."
+                                            },
+                                            "file_name": {
+                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                "description": "The name of the file with extension.",
+                                                "type": "string"
+                                            },
+                                            "file_size_bytes": {
+                                                "description": "File size in bytes.",
+                                                "type": "integer"
+                                            },
+                                            "md5_hash": {
+                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                "type": "string"
+                                            },
+                                            "object_url": {
+                                                "description": "URL to artifact within Google Bucket.",
+                                                "type": "string"
+                                            },
+                                            "upload_placeholder": {
+                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                "type": "string"
+                                            },
+                                            "uploaded_timestamp": {
+                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "uploader": {
+                                                "description": "The name of the person uploading the artifact.",
+                                                "type": "string"
+                                            },
+                                            "uuid": {
+                                                "description": "UUID of artifact.",
+                                                "type": "string"
+                                            },
+                                            "visible": {
+                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "title": "TSV Artifact",
+                                        "type": "object"
+                                    },
                                     "wes_version": {
                                         "$id": "text_artifact",
                                         "$schema": "metaschema/strict_meta_schema.json#",
@@ -9743,6 +10409,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -9866,7 +10533,10 @@
                                     }
                                 },
                                 "required": [
-                                    "wes_version"
+                                    "wes_version",
+                                    "config",
+                                    "wes_run_version",
+                                    "metasheet"
                                 ],
                                 "title": "WES Pipeline Version",
                                 "type": "object"
@@ -9966,6 +10636,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -10172,6 +10843,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -10378,6 +11050,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -10584,6 +11257,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -10790,6 +11464,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -10996,6 +11671,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -11202,6 +11878,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -11433,6 +12110,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -11639,6 +12317,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -11845,6 +12524,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -12051,6 +12731,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -12281,6 +12962,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -12487,6 +13169,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -12693,6 +13376,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -12899,6 +13583,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13105,6 +13790,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13311,6 +13997,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13517,6 +14204,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13723,6 +14411,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -13947,6 +14636,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -14153,6 +14843,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"

--- a/docs/docs/assays.components.composite_image.html
+++ b/docs/docs/assays.components.composite_image.html
@@ -236,6 +236,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -470,6 +471,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -704,6 +706,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.cytof.cytof_analysis.html
+++ b/docs/docs/assays.components.cytof.cytof_analysis.html
@@ -331,6 +331,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -537,6 +538,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -743,6 +745,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -949,6 +952,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1155,6 +1159,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1361,6 +1366,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1567,6 +1573,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.cytof.cytof_entry.html
+++ b/docs/docs/assays.components.cytof.cytof_entry.html
@@ -745,6 +745,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -951,6 +952,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1175,6 +1177,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1381,6 +1384,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1587,6 +1591,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1793,6 +1798,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1999,6 +2005,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2205,6 +2212,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2411,6 +2419,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.components.cytof.cytof_input.html
+++ b/docs/docs/assays.components.cytof.cytof_input.html
@@ -206,6 +206,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -412,6 +413,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.fastq_pair_or_bam.html
+++ b/docs/docs/assays.components.fastq_pair_or_bam.html
@@ -289,6 +289,7 @@
                                     "FCS",
                                     "GZ",
                                     "JSON",
+                                    "YAML",
                                     "[NOT SET]"
                                 ],
                                 "type": "string"
@@ -500,6 +501,7 @@
                                     "FCS",
                                     "GZ",
                                     "JSON",
+                                    "YAML",
                                     "[NOT SET]"
                                 ],
                                 "type": "string"
@@ -711,6 +713,7 @@
                                     "FCS",
                                     "GZ",
                                     "JSON",
+                                    "YAML",
                                     "[NOT SET]"
                                 ],
                                 "type": "string"

--- a/docs/docs/assays.components.imaging.ihc_entry.html
+++ b/docs/docs/assays.components.imaging.ihc_entry.html
@@ -596,6 +596,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.components.imaging.ihc_input.html
+++ b/docs/docs/assays.components.imaging.ihc_input.html
@@ -184,6 +184,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.imaging.micsss_entry.html
+++ b/docs/docs/assays.components.imaging.micsss_entry.html
@@ -270,6 +270,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -504,6 +505,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -738,6 +740,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -990,6 +993,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1224,6 +1228,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1431,6 +1436,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1638,6 +1644,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1873,6 +1880,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -2091,6 +2099,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.components.imaging.micsss_input.html
+++ b/docs/docs/assays.components.imaging.micsss_input.html
@@ -268,6 +268,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -502,6 +503,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -736,6 +738,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -988,6 +991,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1222,6 +1226,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1429,6 +1434,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1636,6 +1642,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1871,6 +1878,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -2089,6 +2097,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.imaging.mif_entry.html
+++ b/docs/docs/assays.components.imaging.mif_entry.html
@@ -225,6 +225,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -444,6 +445,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -678,6 +680,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -885,6 +888,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1092,6 +1096,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1327,6 +1332,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1549,6 +1555,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -1783,6 +1790,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2017,6 +2025,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2263,6 +2272,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2497,6 +2507,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2704,6 +2715,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2911,6 +2923,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3145,6 +3158,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3379,6 +3393,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3613,6 +3628,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3852,6 +3868,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -4079,6 +4096,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -4286,6 +4304,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.components.imaging.mif_input.html
+++ b/docs/docs/assays.components.imaging.mif_input.html
@@ -273,6 +273,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -492,6 +493,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -726,6 +728,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -933,6 +936,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1140,6 +1144,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1375,6 +1380,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -1597,6 +1603,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1831,6 +1838,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2065,6 +2073,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2311,6 +2320,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -2545,6 +2555,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -2752,6 +2763,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -2959,6 +2971,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -3193,6 +3206,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -3427,6 +3441,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -3661,6 +3676,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -3900,6 +3916,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4127,6 +4144,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -4334,6 +4352,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.imaging.mif_roi.html
+++ b/docs/docs/assays.components.imaging.mif_roi.html
@@ -465,6 +465,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -699,6 +700,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -906,6 +908,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1113,6 +1116,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1348,6 +1352,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1570,6 +1575,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1804,6 +1810,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2038,6 +2045,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2284,6 +2292,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -2518,6 +2527,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -2725,6 +2735,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -2932,6 +2943,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -3166,6 +3178,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -3400,6 +3413,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -3634,6 +3648,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -3873,6 +3888,7 @@
                                     "FCS",
                                     "GZ",
                                     "JSON",
+                                    "YAML",
                                     "[NOT SET]"
                                 ],
                                 "type": "string"

--- a/docs/docs/assays.components.mapping.html
+++ b/docs/docs/assays.components.mapping.html
@@ -298,6 +298,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -532,6 +533,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -739,6 +741,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -946,6 +949,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1181,6 +1185,7 @@
                                     "FCS",
                                     "GZ",
                                     "JSON",
+                                    "YAML",
                                     "[NOT SET]"
                                 ],
                                 "type": "string"

--- a/docs/docs/assays.components.ngs.ngs_assay_record.html
+++ b/docs/docs/assays.components.ngs.ngs_assay_record.html
@@ -241,6 +241,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -452,6 +453,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -663,6 +665,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"

--- a/docs/docs/assays.components.ngs.rna.rna_entry.html
+++ b/docs/docs/assays.components.ngs.rna.rna_entry.html
@@ -444,6 +444,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -655,6 +656,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -866,6 +868,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1128,6 +1131,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1339,6 +1343,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1550,6 +1555,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"

--- a/docs/docs/assays.components.ngs.rna.rnaseq_analysis.html
+++ b/docs/docs/assays.components.ngs.rna.rnaseq_analysis.html
@@ -216,6 +216,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -422,6 +423,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -628,6 +630,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -834,6 +837,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1040,6 +1044,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1263,6 +1268,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1469,6 +1475,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1675,6 +1682,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1881,6 +1889,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2087,6 +2096,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2293,6 +2303,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2499,6 +2510,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2705,6 +2717,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2911,6 +2924,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3117,6 +3131,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3345,6 +3360,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3551,6 +3567,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3757,6 +3774,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3963,6 +3981,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -4169,6 +4188,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"

--- a/docs/docs/assays.components.ngs.rna.rnaseq_level1_analysis.html
+++ b/docs/docs/assays.components.ngs.rna.rnaseq_level1_analysis.html
@@ -278,6 +278,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -484,6 +485,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -690,6 +692,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -896,6 +899,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1102,6 +1106,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1325,6 +1330,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1531,6 +1537,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1737,6 +1744,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1943,6 +1951,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2149,6 +2158,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2355,6 +2365,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2561,6 +2572,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2767,6 +2779,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2973,6 +2986,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -3179,6 +3193,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -3407,6 +3422,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -3613,6 +3629,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -3819,6 +3836,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -4025,6 +4043,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -4231,6 +4250,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.components.ngs.rna.rseqc.html
+++ b/docs/docs/assays.components.ngs.rna.rseqc.html
@@ -291,6 +291,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -497,6 +498,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -703,6 +705,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -909,6 +912,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1115,6 +1119,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.rna.salmon.html
+++ b/docs/docs/assays.components.ngs.rna.salmon.html
@@ -426,6 +426,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -632,6 +633,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -838,6 +840,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1044,6 +1047,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1250,6 +1254,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1456,6 +1461,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1662,6 +1668,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1868,6 +1875,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -2074,6 +2082,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -2280,6 +2289,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.rna.star.html
+++ b/docs/docs/assays.components.ngs.rna.star.html
@@ -291,6 +291,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -497,6 +498,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -703,6 +705,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -909,6 +912,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1115,6 +1119,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.alignment.html
+++ b/docs/docs/assays.components.ngs.wes.alignment.html
@@ -264,6 +264,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -470,6 +471,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -676,6 +678,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -882,6 +885,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.clonality.html
+++ b/docs/docs/assays.components.ngs.wes.clonality.html
@@ -183,6 +183,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.copynumber.html
+++ b/docs/docs/assays.components.ngs.wes.copynumber.html
@@ -210,6 +210,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -416,6 +417,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.corealignments.html
+++ b/docs/docs/assays.components.ngs.wes.corealignments.html
@@ -208,6 +208,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -414,6 +415,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.coverage_metrics.html
+++ b/docs/docs/assays.components.ngs.wes.coverage_metrics.html
@@ -368,6 +368,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -574,6 +575,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -780,6 +782,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -986,6 +989,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1192,6 +1196,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1398,6 +1403,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1604,6 +1610,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1810,6 +1817,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.germline.html
+++ b/docs/docs/assays.components.ngs.wes.germline.html
@@ -183,6 +183,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.neoantigen.html
+++ b/docs/docs/assays.components.ngs.wes.neoantigen.html
@@ -264,6 +264,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -470,6 +471,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -676,6 +678,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -882,6 +885,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.optitype.html
+++ b/docs/docs/assays.components.ngs.wes.optitype.html
@@ -208,6 +208,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -414,6 +415,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.purity.html
+++ b/docs/docs/assays.components.ngs.wes.purity.html
@@ -183,6 +183,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.report.html
+++ b/docs/docs/assays.components.ngs.wes.report.html
@@ -82,6 +82,87 @@
 </tr>
             
         
+            
+                <tr>
+    <td>
+        
+            <span id="config">
+                config
+            </span>
+            
+                <br><sup><mark>required</mark></sup>
+            
+        
+    </td>
+    <td width=55%>
+        
+            Information about a YAML file.
+        
+    </td>
+    <td>
+        
+            <a href="artifacts.artifact_yaml.html">artifacts.artifact_yaml</a>
+        
+    </td>
+</tr>
+            
+        
+            
+                <tr>
+    <td>
+        
+            <span id="wes_run_version">
+                wes_run_version
+            </span>
+            
+                <br><sup><mark>required</mark></sup>
+            
+        
+    </td>
+    <td width=55%>
+        
+            Information about a tab Separated file.
+        
+    </td>
+    <td>
+        
+            <a href="artifacts.artifact_tsv.html">artifacts.artifact_tsv</a>
+        
+    </td>
+</tr>
+            
+        
+            
+                <tr>
+    <td>
+        
+            <span id="metasheet">
+                metasheet
+            </span>
+            
+                <br><sup><mark>required</mark></sup>
+            
+        
+    </td>
+    <td width=55%>
+        
+            Information about a comma separated file.
+        
+    </td>
+    <td>
+        
+            <a href="artifacts.artifact_csv.html">artifacts.artifact_csv</a>
+        
+    </td>
+</tr>
+            
+        
+        
+            
+        
+            
+        
+            
         
             
         
@@ -98,6 +179,627 @@
     "additionalProperties": false,
     "description": "WES pipeline version/commit string.",
     "properties": {
+        "config": {
+            "$id": "yaml_artifact",
+            "$schema": "metaschema/strict_meta_schema.json#",
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "$id": "artifact_core",
+                    "$schema": "metaschema/strict_meta_schema.json#",
+                    "anyOf": [
+                        {
+                            "required": [
+                                "file_name",
+                                "object_url",
+                                "uploaded_timestamp",
+                                "file_size_bytes",
+                                "artifact_category",
+                                "data_format",
+                                "md5_hash"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "file_name",
+                                "object_url",
+                                "uploaded_timestamp",
+                                "file_size_bytes",
+                                "artifact_category",
+                                "data_format",
+                                "crc32c_hash"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "upload_placeholder"
+                            ]
+                        }
+                    ],
+                    "description": "Any file artifact associated with a clinical trial.",
+                    "inheritableBase": true,
+                    "properties": {
+                        "artifact_category": {
+                            "description": "Artifact category.",
+                            "enum": [
+                                "Assay Artifact from CIMAC",
+                                "Pipeline Artifact",
+                                "Manifest File"
+                            ],
+                            "type": "string"
+                        },
+                        "artifact_creator": {
+                            "description": "The name of the center that created this artifact.",
+                            "enum": [
+                                "DFCI",
+                                "Mount Sinai",
+                                "Stanford",
+                                "MD Anderson"
+                            ],
+                            "type": "string"
+                        },
+                        "crc32c_hash": {
+                            "description": "CRC32c Hash of artifact.",
+                            "type": "string"
+                        },
+                        "data_format": {
+                            "description": "Data Format.",
+                            "enum": [
+                                "FASTA",
+                                "FASTQ.GZ",
+                                "VCF.GZ",
+                                "IMAGE",
+                                "VCF",
+                                "CSV",
+                                "TSV",
+                                "XLSX",
+                                "NPX",
+                                "ELISA",
+                                "BAM",
+                                "BAM.BAI",
+                                "MAF",
+                                "BINARY",
+                                "TEXT",
+                                "ZIP",
+                                "FCS",
+                                "GZ",
+                                "JSON",
+                                "YAML",
+                                "[NOT SET]"
+                            ],
+                            "type": "string"
+                        },
+                        "file_name": {
+                            "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                            "description": "The name of the file with extension.",
+                            "type": "string"
+                        },
+                        "file_size_bytes": {
+                            "description": "File size in bytes.",
+                            "type": "integer"
+                        },
+                        "md5_hash": {
+                            "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                            "type": "string"
+                        },
+                        "object_url": {
+                            "description": "URL to artifact within Google Bucket.",
+                            "type": "string"
+                        },
+                        "upload_placeholder": {
+                            "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                            "description": "A placeholder for when artifact file is being uploaded.",
+                            "type": "string"
+                        },
+                        "uploaded_timestamp": {
+                            "description": "Timestamp of when artifact was loaded into the system.",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "uploader": {
+                            "description": "The name of the person uploading the artifact.",
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "description": "UUID of artifact.",
+                            "type": "string"
+                        },
+                        "visible": {
+                            "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                            "type": "boolean"
+                        }
+                    },
+                    "title": "Artifact Core",
+                    "type": "object"
+                }
+            ],
+            "description": "Information about a YAML file.",
+            "mergeStrategy": "objectMerge",
+            "properties": {
+                "artifact_category": {
+                    "description": "Artifact category.",
+                    "enum": [
+                        "Assay Artifact from CIMAC",
+                        "Pipeline Artifact",
+                        "Manifest File"
+                    ],
+                    "type": "string"
+                },
+                "artifact_creator": {
+                    "description": "The name of the center that created this artifact.",
+                    "enum": [
+                        "DFCI",
+                        "Mount Sinai",
+                        "Stanford",
+                        "MD Anderson"
+                    ],
+                    "type": "string"
+                },
+                "crc32c_hash": {
+                    "description": "CRC32c Hash of artifact.",
+                    "type": "string"
+                },
+                "data_format": {
+                    "const": "YAML",
+                    "description": "Data format."
+                },
+                "file_name": {
+                    "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                    "description": "The name of the file with extension.",
+                    "type": "string"
+                },
+                "file_size_bytes": {
+                    "description": "File size in bytes.",
+                    "type": "integer"
+                },
+                "md5_hash": {
+                    "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                    "type": "string"
+                },
+                "object_url": {
+                    "description": "URL to artifact within Google Bucket.",
+                    "type": "string"
+                },
+                "upload_placeholder": {
+                    "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                    "description": "A placeholder for when artifact file is being uploaded.",
+                    "type": "string"
+                },
+                "uploaded_timestamp": {
+                    "description": "Timestamp of when artifact was loaded into the system.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "uploader": {
+                    "description": "The name of the person uploading the artifact.",
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "UUID of artifact.",
+                    "type": "string"
+                },
+                "visible": {
+                    "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                    "type": "boolean"
+                }
+            },
+            "title": "YAML Artifact",
+            "type": "object"
+        },
+        "metasheet": {
+            "$id": "csv_artifact",
+            "$schema": "metaschema/strict_meta_schema.json#",
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "$id": "artifact_core",
+                    "$schema": "metaschema/strict_meta_schema.json#",
+                    "anyOf": [
+                        {
+                            "required": [
+                                "file_name",
+                                "object_url",
+                                "uploaded_timestamp",
+                                "file_size_bytes",
+                                "artifact_category",
+                                "data_format",
+                                "md5_hash"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "file_name",
+                                "object_url",
+                                "uploaded_timestamp",
+                                "file_size_bytes",
+                                "artifact_category",
+                                "data_format",
+                                "crc32c_hash"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "upload_placeholder"
+                            ]
+                        }
+                    ],
+                    "description": "Any file artifact associated with a clinical trial.",
+                    "inheritableBase": true,
+                    "properties": {
+                        "artifact_category": {
+                            "description": "Artifact category.",
+                            "enum": [
+                                "Assay Artifact from CIMAC",
+                                "Pipeline Artifact",
+                                "Manifest File"
+                            ],
+                            "type": "string"
+                        },
+                        "artifact_creator": {
+                            "description": "The name of the center that created this artifact.",
+                            "enum": [
+                                "DFCI",
+                                "Mount Sinai",
+                                "Stanford",
+                                "MD Anderson"
+                            ],
+                            "type": "string"
+                        },
+                        "crc32c_hash": {
+                            "description": "CRC32c Hash of artifact.",
+                            "type": "string"
+                        },
+                        "data_format": {
+                            "description": "Data Format.",
+                            "enum": [
+                                "FASTA",
+                                "FASTQ.GZ",
+                                "VCF.GZ",
+                                "IMAGE",
+                                "VCF",
+                                "CSV",
+                                "TSV",
+                                "XLSX",
+                                "NPX",
+                                "ELISA",
+                                "BAM",
+                                "BAM.BAI",
+                                "MAF",
+                                "BINARY",
+                                "TEXT",
+                                "ZIP",
+                                "FCS",
+                                "GZ",
+                                "JSON",
+                                "YAML",
+                                "[NOT SET]"
+                            ],
+                            "type": "string"
+                        },
+                        "file_name": {
+                            "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                            "description": "The name of the file with extension.",
+                            "type": "string"
+                        },
+                        "file_size_bytes": {
+                            "description": "File size in bytes.",
+                            "type": "integer"
+                        },
+                        "md5_hash": {
+                            "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                            "type": "string"
+                        },
+                        "object_url": {
+                            "description": "URL to artifact within Google Bucket.",
+                            "type": "string"
+                        },
+                        "upload_placeholder": {
+                            "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                            "description": "A placeholder for when artifact file is being uploaded.",
+                            "type": "string"
+                        },
+                        "uploaded_timestamp": {
+                            "description": "Timestamp of when artifact was loaded into the system.",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "uploader": {
+                            "description": "The name of the person uploading the artifact.",
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "description": "UUID of artifact.",
+                            "type": "string"
+                        },
+                        "visible": {
+                            "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                            "type": "boolean"
+                        }
+                    },
+                    "title": "Artifact Core",
+                    "type": "object"
+                }
+            ],
+            "description": "Information about a comma separated file.",
+            "mergeStrategy": "objectMerge",
+            "properties": {
+                "artifact_category": {
+                    "description": "Artifact category.",
+                    "enum": [
+                        "Assay Artifact from CIMAC",
+                        "Pipeline Artifact",
+                        "Manifest File"
+                    ],
+                    "type": "string"
+                },
+                "artifact_creator": {
+                    "description": "The name of the center that created this artifact.",
+                    "enum": [
+                        "DFCI",
+                        "Mount Sinai",
+                        "Stanford",
+                        "MD Anderson"
+                    ],
+                    "type": "string"
+                },
+                "crc32c_hash": {
+                    "description": "CRC32c Hash of artifact.",
+                    "type": "string"
+                },
+                "data_format": {
+                    "const": "CSV",
+                    "description": "Data format."
+                },
+                "file_name": {
+                    "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                    "description": "The name of the file with extension.",
+                    "type": "string"
+                },
+                "file_size_bytes": {
+                    "description": "File size in bytes.",
+                    "type": "integer"
+                },
+                "md5_hash": {
+                    "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                    "type": "string"
+                },
+                "object_url": {
+                    "description": "URL to artifact within Google Bucket.",
+                    "type": "string"
+                },
+                "upload_placeholder": {
+                    "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                    "description": "A placeholder for when artifact file is being uploaded.",
+                    "type": "string"
+                },
+                "uploaded_timestamp": {
+                    "description": "Timestamp of when artifact was loaded into the system.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "uploader": {
+                    "description": "The name of the person uploading the artifact.",
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "UUID of artifact.",
+                    "type": "string"
+                },
+                "visible": {
+                    "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                    "type": "boolean"
+                }
+            },
+            "title": "CSV Artifact",
+            "type": "object"
+        },
+        "wes_run_version": {
+            "$id": "tsv_artifact",
+            "$schema": "metaschema/strict_meta_schema.json#",
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "$id": "artifact_core",
+                    "$schema": "metaschema/strict_meta_schema.json#",
+                    "anyOf": [
+                        {
+                            "required": [
+                                "file_name",
+                                "object_url",
+                                "uploaded_timestamp",
+                                "file_size_bytes",
+                                "artifact_category",
+                                "data_format",
+                                "md5_hash"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "file_name",
+                                "object_url",
+                                "uploaded_timestamp",
+                                "file_size_bytes",
+                                "artifact_category",
+                                "data_format",
+                                "crc32c_hash"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "upload_placeholder"
+                            ]
+                        }
+                    ],
+                    "description": "Any file artifact associated with a clinical trial.",
+                    "inheritableBase": true,
+                    "properties": {
+                        "artifact_category": {
+                            "description": "Artifact category.",
+                            "enum": [
+                                "Assay Artifact from CIMAC",
+                                "Pipeline Artifact",
+                                "Manifest File"
+                            ],
+                            "type": "string"
+                        },
+                        "artifact_creator": {
+                            "description": "The name of the center that created this artifact.",
+                            "enum": [
+                                "DFCI",
+                                "Mount Sinai",
+                                "Stanford",
+                                "MD Anderson"
+                            ],
+                            "type": "string"
+                        },
+                        "crc32c_hash": {
+                            "description": "CRC32c Hash of artifact.",
+                            "type": "string"
+                        },
+                        "data_format": {
+                            "description": "Data Format.",
+                            "enum": [
+                                "FASTA",
+                                "FASTQ.GZ",
+                                "VCF.GZ",
+                                "IMAGE",
+                                "VCF",
+                                "CSV",
+                                "TSV",
+                                "XLSX",
+                                "NPX",
+                                "ELISA",
+                                "BAM",
+                                "BAM.BAI",
+                                "MAF",
+                                "BINARY",
+                                "TEXT",
+                                "ZIP",
+                                "FCS",
+                                "GZ",
+                                "JSON",
+                                "YAML",
+                                "[NOT SET]"
+                            ],
+                            "type": "string"
+                        },
+                        "file_name": {
+                            "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                            "description": "The name of the file with extension.",
+                            "type": "string"
+                        },
+                        "file_size_bytes": {
+                            "description": "File size in bytes.",
+                            "type": "integer"
+                        },
+                        "md5_hash": {
+                            "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                            "type": "string"
+                        },
+                        "object_url": {
+                            "description": "URL to artifact within Google Bucket.",
+                            "type": "string"
+                        },
+                        "upload_placeholder": {
+                            "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                            "description": "A placeholder for when artifact file is being uploaded.",
+                            "type": "string"
+                        },
+                        "uploaded_timestamp": {
+                            "description": "Timestamp of when artifact was loaded into the system.",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "uploader": {
+                            "description": "The name of the person uploading the artifact.",
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "description": "UUID of artifact.",
+                            "type": "string"
+                        },
+                        "visible": {
+                            "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                            "type": "boolean"
+                        }
+                    },
+                    "title": "Artifact Core",
+                    "type": "object"
+                }
+            ],
+            "description": "Information about a tab Separated file.",
+            "mergeStrategy": "objectMerge",
+            "properties": {
+                "artifact_category": {
+                    "description": "Artifact category.",
+                    "enum": [
+                        "Assay Artifact from CIMAC",
+                        "Pipeline Artifact",
+                        "Manifest File"
+                    ],
+                    "type": "string"
+                },
+                "artifact_creator": {
+                    "description": "The name of the center that created this artifact.",
+                    "enum": [
+                        "DFCI",
+                        "Mount Sinai",
+                        "Stanford",
+                        "MD Anderson"
+                    ],
+                    "type": "string"
+                },
+                "crc32c_hash": {
+                    "description": "CRC32c Hash of artifact.",
+                    "type": "string"
+                },
+                "data_format": {
+                    "const": "TSV",
+                    "description": "Data format."
+                },
+                "file_name": {
+                    "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                    "description": "The name of the file with extension.",
+                    "type": "string"
+                },
+                "file_size_bytes": {
+                    "description": "File size in bytes.",
+                    "type": "integer"
+                },
+                "md5_hash": {
+                    "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                    "type": "string"
+                },
+                "object_url": {
+                    "description": "URL to artifact within Google Bucket.",
+                    "type": "string"
+                },
+                "upload_placeholder": {
+                    "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                    "description": "A placeholder for when artifact file is being uploaded.",
+                    "type": "string"
+                },
+                "uploaded_timestamp": {
+                    "description": "Timestamp of when artifact was loaded into the system.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "uploader": {
+                    "description": "The name of the person uploading the artifact.",
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "UUID of artifact.",
+                    "type": "string"
+                },
+                "visible": {
+                    "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                    "type": "boolean"
+                }
+            },
+            "title": "TSV Artifact",
+            "type": "object"
+        },
         "wes_version": {
             "$id": "text_artifact",
             "$schema": "metaschema/strict_meta_schema.json#",
@@ -183,6 +885,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -306,7 +1009,10 @@
         }
     },
     "required": [
-        "wes_version"
+        "wes_version",
+        "config",
+        "wes_run_version",
+        "metasheet"
     ],
     "title": "WES Pipeline Version",
     "type": "object"

--- a/docs/docs/assays.components.ngs.wes.somatic.html
+++ b/docs/docs/assays.components.ngs.wes.somatic.html
@@ -345,6 +345,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -551,6 +552,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -757,6 +759,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -963,6 +966,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1169,6 +1173,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1375,6 +1380,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1581,6 +1587,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.wes_analysis.html
+++ b/docs/docs/assays.components.ngs.wes.wes_analysis.html
@@ -208,6 +208,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -427,6 +428,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -633,6 +635,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -853,6 +856,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1059,6 +1063,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1278,6 +1283,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1497,6 +1503,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1703,6 +1710,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1909,6 +1917,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2115,6 +2124,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2343,6 +2353,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2549,6 +2560,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2755,6 +2767,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2961,6 +2974,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3191,6 +3205,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3397,6 +3412,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3603,6 +3619,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3809,6 +3826,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4015,6 +4033,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4221,6 +4240,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4427,6 +4447,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4633,6 +4654,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4857,6 +4879,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -5063,6 +5086,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -5289,6 +5313,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -5423,6 +5448,627 @@
                         "additionalProperties": false,
                         "description": "WES pipeline version/commit string.",
                         "properties": {
+                            "config": {
+                                "$id": "yaml_artifact",
+                                "$schema": "metaschema/strict_meta_schema.json#",
+                                "additionalProperties": false,
+                                "allOf": [
+                                    {
+                                        "$id": "artifact_core",
+                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "file_name",
+                                                    "object_url",
+                                                    "uploaded_timestamp",
+                                                    "file_size_bytes",
+                                                    "artifact_category",
+                                                    "data_format",
+                                                    "md5_hash"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "file_name",
+                                                    "object_url",
+                                                    "uploaded_timestamp",
+                                                    "file_size_bytes",
+                                                    "artifact_category",
+                                                    "data_format",
+                                                    "crc32c_hash"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "upload_placeholder"
+                                                ]
+                                            }
+                                        ],
+                                        "description": "Any file artifact associated with a clinical trial.",
+                                        "inheritableBase": true,
+                                        "properties": {
+                                            "artifact_category": {
+                                                "description": "Artifact category.",
+                                                "enum": [
+                                                    "Assay Artifact from CIMAC",
+                                                    "Pipeline Artifact",
+                                                    "Manifest File"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "artifact_creator": {
+                                                "description": "The name of the center that created this artifact.",
+                                                "enum": [
+                                                    "DFCI",
+                                                    "Mount Sinai",
+                                                    "Stanford",
+                                                    "MD Anderson"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "crc32c_hash": {
+                                                "description": "CRC32c Hash of artifact.",
+                                                "type": "string"
+                                            },
+                                            "data_format": {
+                                                "description": "Data Format.",
+                                                "enum": [
+                                                    "FASTA",
+                                                    "FASTQ.GZ",
+                                                    "VCF.GZ",
+                                                    "IMAGE",
+                                                    "VCF",
+                                                    "CSV",
+                                                    "TSV",
+                                                    "XLSX",
+                                                    "NPX",
+                                                    "ELISA",
+                                                    "BAM",
+                                                    "BAM.BAI",
+                                                    "MAF",
+                                                    "BINARY",
+                                                    "TEXT",
+                                                    "ZIP",
+                                                    "FCS",
+                                                    "GZ",
+                                                    "JSON",
+                                                    "YAML",
+                                                    "[NOT SET]"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "file_name": {
+                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                "description": "The name of the file with extension.",
+                                                "type": "string"
+                                            },
+                                            "file_size_bytes": {
+                                                "description": "File size in bytes.",
+                                                "type": "integer"
+                                            },
+                                            "md5_hash": {
+                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                "type": "string"
+                                            },
+                                            "object_url": {
+                                                "description": "URL to artifact within Google Bucket.",
+                                                "type": "string"
+                                            },
+                                            "upload_placeholder": {
+                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                "type": "string"
+                                            },
+                                            "uploaded_timestamp": {
+                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "uploader": {
+                                                "description": "The name of the person uploading the artifact.",
+                                                "type": "string"
+                                            },
+                                            "uuid": {
+                                                "description": "UUID of artifact.",
+                                                "type": "string"
+                                            },
+                                            "visible": {
+                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "title": "Artifact Core",
+                                        "type": "object"
+                                    }
+                                ],
+                                "description": "Information about a YAML file.",
+                                "mergeStrategy": "objectMerge",
+                                "properties": {
+                                    "artifact_category": {
+                                        "description": "Artifact category.",
+                                        "enum": [
+                                            "Assay Artifact from CIMAC",
+                                            "Pipeline Artifact",
+                                            "Manifest File"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "artifact_creator": {
+                                        "description": "The name of the center that created this artifact.",
+                                        "enum": [
+                                            "DFCI",
+                                            "Mount Sinai",
+                                            "Stanford",
+                                            "MD Anderson"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "crc32c_hash": {
+                                        "description": "CRC32c Hash of artifact.",
+                                        "type": "string"
+                                    },
+                                    "data_format": {
+                                        "const": "YAML",
+                                        "description": "Data format."
+                                    },
+                                    "file_name": {
+                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                        "description": "The name of the file with extension.",
+                                        "type": "string"
+                                    },
+                                    "file_size_bytes": {
+                                        "description": "File size in bytes.",
+                                        "type": "integer"
+                                    },
+                                    "md5_hash": {
+                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                        "type": "string"
+                                    },
+                                    "object_url": {
+                                        "description": "URL to artifact within Google Bucket.",
+                                        "type": "string"
+                                    },
+                                    "upload_placeholder": {
+                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                        "type": "string"
+                                    },
+                                    "uploaded_timestamp": {
+                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "uploader": {
+                                        "description": "The name of the person uploading the artifact.",
+                                        "type": "string"
+                                    },
+                                    "uuid": {
+                                        "description": "UUID of artifact.",
+                                        "type": "string"
+                                    },
+                                    "visible": {
+                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "title": "YAML Artifact",
+                                "type": "object"
+                            },
+                            "metasheet": {
+                                "$id": "csv_artifact",
+                                "$schema": "metaschema/strict_meta_schema.json#",
+                                "additionalProperties": false,
+                                "allOf": [
+                                    {
+                                        "$id": "artifact_core",
+                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "file_name",
+                                                    "object_url",
+                                                    "uploaded_timestamp",
+                                                    "file_size_bytes",
+                                                    "artifact_category",
+                                                    "data_format",
+                                                    "md5_hash"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "file_name",
+                                                    "object_url",
+                                                    "uploaded_timestamp",
+                                                    "file_size_bytes",
+                                                    "artifact_category",
+                                                    "data_format",
+                                                    "crc32c_hash"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "upload_placeholder"
+                                                ]
+                                            }
+                                        ],
+                                        "description": "Any file artifact associated with a clinical trial.",
+                                        "inheritableBase": true,
+                                        "properties": {
+                                            "artifact_category": {
+                                                "description": "Artifact category.",
+                                                "enum": [
+                                                    "Assay Artifact from CIMAC",
+                                                    "Pipeline Artifact",
+                                                    "Manifest File"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "artifact_creator": {
+                                                "description": "The name of the center that created this artifact.",
+                                                "enum": [
+                                                    "DFCI",
+                                                    "Mount Sinai",
+                                                    "Stanford",
+                                                    "MD Anderson"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "crc32c_hash": {
+                                                "description": "CRC32c Hash of artifact.",
+                                                "type": "string"
+                                            },
+                                            "data_format": {
+                                                "description": "Data Format.",
+                                                "enum": [
+                                                    "FASTA",
+                                                    "FASTQ.GZ",
+                                                    "VCF.GZ",
+                                                    "IMAGE",
+                                                    "VCF",
+                                                    "CSV",
+                                                    "TSV",
+                                                    "XLSX",
+                                                    "NPX",
+                                                    "ELISA",
+                                                    "BAM",
+                                                    "BAM.BAI",
+                                                    "MAF",
+                                                    "BINARY",
+                                                    "TEXT",
+                                                    "ZIP",
+                                                    "FCS",
+                                                    "GZ",
+                                                    "JSON",
+                                                    "YAML",
+                                                    "[NOT SET]"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "file_name": {
+                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                "description": "The name of the file with extension.",
+                                                "type": "string"
+                                            },
+                                            "file_size_bytes": {
+                                                "description": "File size in bytes.",
+                                                "type": "integer"
+                                            },
+                                            "md5_hash": {
+                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                "type": "string"
+                                            },
+                                            "object_url": {
+                                                "description": "URL to artifact within Google Bucket.",
+                                                "type": "string"
+                                            },
+                                            "upload_placeholder": {
+                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                "type": "string"
+                                            },
+                                            "uploaded_timestamp": {
+                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "uploader": {
+                                                "description": "The name of the person uploading the artifact.",
+                                                "type": "string"
+                                            },
+                                            "uuid": {
+                                                "description": "UUID of artifact.",
+                                                "type": "string"
+                                            },
+                                            "visible": {
+                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "title": "Artifact Core",
+                                        "type": "object"
+                                    }
+                                ],
+                                "description": "Information about a comma separated file.",
+                                "mergeStrategy": "objectMerge",
+                                "properties": {
+                                    "artifact_category": {
+                                        "description": "Artifact category.",
+                                        "enum": [
+                                            "Assay Artifact from CIMAC",
+                                            "Pipeline Artifact",
+                                            "Manifest File"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "artifact_creator": {
+                                        "description": "The name of the center that created this artifact.",
+                                        "enum": [
+                                            "DFCI",
+                                            "Mount Sinai",
+                                            "Stanford",
+                                            "MD Anderson"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "crc32c_hash": {
+                                        "description": "CRC32c Hash of artifact.",
+                                        "type": "string"
+                                    },
+                                    "data_format": {
+                                        "const": "CSV",
+                                        "description": "Data format."
+                                    },
+                                    "file_name": {
+                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                        "description": "The name of the file with extension.",
+                                        "type": "string"
+                                    },
+                                    "file_size_bytes": {
+                                        "description": "File size in bytes.",
+                                        "type": "integer"
+                                    },
+                                    "md5_hash": {
+                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                        "type": "string"
+                                    },
+                                    "object_url": {
+                                        "description": "URL to artifact within Google Bucket.",
+                                        "type": "string"
+                                    },
+                                    "upload_placeholder": {
+                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                        "type": "string"
+                                    },
+                                    "uploaded_timestamp": {
+                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "uploader": {
+                                        "description": "The name of the person uploading the artifact.",
+                                        "type": "string"
+                                    },
+                                    "uuid": {
+                                        "description": "UUID of artifact.",
+                                        "type": "string"
+                                    },
+                                    "visible": {
+                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "title": "CSV Artifact",
+                                "type": "object"
+                            },
+                            "wes_run_version": {
+                                "$id": "tsv_artifact",
+                                "$schema": "metaschema/strict_meta_schema.json#",
+                                "additionalProperties": false,
+                                "allOf": [
+                                    {
+                                        "$id": "artifact_core",
+                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "file_name",
+                                                    "object_url",
+                                                    "uploaded_timestamp",
+                                                    "file_size_bytes",
+                                                    "artifact_category",
+                                                    "data_format",
+                                                    "md5_hash"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "file_name",
+                                                    "object_url",
+                                                    "uploaded_timestamp",
+                                                    "file_size_bytes",
+                                                    "artifact_category",
+                                                    "data_format",
+                                                    "crc32c_hash"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "upload_placeholder"
+                                                ]
+                                            }
+                                        ],
+                                        "description": "Any file artifact associated with a clinical trial.",
+                                        "inheritableBase": true,
+                                        "properties": {
+                                            "artifact_category": {
+                                                "description": "Artifact category.",
+                                                "enum": [
+                                                    "Assay Artifact from CIMAC",
+                                                    "Pipeline Artifact",
+                                                    "Manifest File"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "artifact_creator": {
+                                                "description": "The name of the center that created this artifact.",
+                                                "enum": [
+                                                    "DFCI",
+                                                    "Mount Sinai",
+                                                    "Stanford",
+                                                    "MD Anderson"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "crc32c_hash": {
+                                                "description": "CRC32c Hash of artifact.",
+                                                "type": "string"
+                                            },
+                                            "data_format": {
+                                                "description": "Data Format.",
+                                                "enum": [
+                                                    "FASTA",
+                                                    "FASTQ.GZ",
+                                                    "VCF.GZ",
+                                                    "IMAGE",
+                                                    "VCF",
+                                                    "CSV",
+                                                    "TSV",
+                                                    "XLSX",
+                                                    "NPX",
+                                                    "ELISA",
+                                                    "BAM",
+                                                    "BAM.BAI",
+                                                    "MAF",
+                                                    "BINARY",
+                                                    "TEXT",
+                                                    "ZIP",
+                                                    "FCS",
+                                                    "GZ",
+                                                    "JSON",
+                                                    "YAML",
+                                                    "[NOT SET]"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "file_name": {
+                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                "description": "The name of the file with extension.",
+                                                "type": "string"
+                                            },
+                                            "file_size_bytes": {
+                                                "description": "File size in bytes.",
+                                                "type": "integer"
+                                            },
+                                            "md5_hash": {
+                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                "type": "string"
+                                            },
+                                            "object_url": {
+                                                "description": "URL to artifact within Google Bucket.",
+                                                "type": "string"
+                                            },
+                                            "upload_placeholder": {
+                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                "type": "string"
+                                            },
+                                            "uploaded_timestamp": {
+                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "uploader": {
+                                                "description": "The name of the person uploading the artifact.",
+                                                "type": "string"
+                                            },
+                                            "uuid": {
+                                                "description": "UUID of artifact.",
+                                                "type": "string"
+                                            },
+                                            "visible": {
+                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "title": "Artifact Core",
+                                        "type": "object"
+                                    }
+                                ],
+                                "description": "Information about a tab Separated file.",
+                                "mergeStrategy": "objectMerge",
+                                "properties": {
+                                    "artifact_category": {
+                                        "description": "Artifact category.",
+                                        "enum": [
+                                            "Assay Artifact from CIMAC",
+                                            "Pipeline Artifact",
+                                            "Manifest File"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "artifact_creator": {
+                                        "description": "The name of the center that created this artifact.",
+                                        "enum": [
+                                            "DFCI",
+                                            "Mount Sinai",
+                                            "Stanford",
+                                            "MD Anderson"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "crc32c_hash": {
+                                        "description": "CRC32c Hash of artifact.",
+                                        "type": "string"
+                                    },
+                                    "data_format": {
+                                        "const": "TSV",
+                                        "description": "Data format."
+                                    },
+                                    "file_name": {
+                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                        "description": "The name of the file with extension.",
+                                        "type": "string"
+                                    },
+                                    "file_size_bytes": {
+                                        "description": "File size in bytes.",
+                                        "type": "integer"
+                                    },
+                                    "md5_hash": {
+                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                        "type": "string"
+                                    },
+                                    "object_url": {
+                                        "description": "URL to artifact within Google Bucket.",
+                                        "type": "string"
+                                    },
+                                    "upload_placeholder": {
+                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                        "type": "string"
+                                    },
+                                    "uploaded_timestamp": {
+                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "uploader": {
+                                        "description": "The name of the person uploading the artifact.",
+                                        "type": "string"
+                                    },
+                                    "uuid": {
+                                        "description": "UUID of artifact.",
+                                        "type": "string"
+                                    },
+                                    "visible": {
+                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "title": "TSV Artifact",
+                                "type": "object"
+                            },
                             "wes_version": {
                                 "$id": "text_artifact",
                                 "$schema": "metaschema/strict_meta_schema.json#",
@@ -5508,6 +6154,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -5631,7 +6278,10 @@
                             }
                         },
                         "required": [
-                            "wes_version"
+                            "wes_version",
+                            "config",
+                            "wes_run_version",
+                            "metasheet"
                         ],
                         "title": "WES Pipeline Version",
                         "type": "object"
@@ -5731,6 +6381,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -5937,6 +6588,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -6143,6 +6795,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -6349,6 +7002,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -6555,6 +7209,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -6761,6 +7416,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -6967,6 +7623,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -7198,6 +7855,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -7404,6 +8062,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -7610,6 +8269,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -7816,6 +8476,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -8046,6 +8707,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -8252,6 +8914,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -8458,6 +9121,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -8664,6 +9328,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -8870,6 +9535,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -9076,6 +9742,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -9282,6 +9949,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -9488,6 +10156,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -9712,6 +10381,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -9918,6 +10588,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"

--- a/docs/docs/assays.components.ngs.wes.wes_entry.html
+++ b/docs/docs/assays.components.ngs.wes.wes_entry.html
@@ -364,6 +364,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -575,6 +576,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -786,6 +788,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1042,6 +1045,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1253,6 +1257,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1464,6 +1469,7 @@
                                             "FCS",
                                             "GZ",
                                             "JSON",
+                                            "YAML",
                                             "[NOT SET]"
                                         ],
                                         "type": "string"
@@ -1689,6 +1695,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -1895,6 +1902,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -2101,6 +2109,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -2307,6 +2316,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -2537,6 +2547,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -2743,6 +2754,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -2949,6 +2961,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3155,6 +3168,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3361,6 +3375,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3567,6 +3582,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3773,6 +3789,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3979,6 +3996,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4203,6 +4221,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4409,6 +4428,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.wes_pair_analysis.html
+++ b/docs/docs/assays.components.ngs.wes.wes_pair_analysis.html
@@ -453,6 +453,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -672,6 +673,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -878,6 +880,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1098,6 +1101,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1304,6 +1308,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1523,6 +1528,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1742,6 +1748,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1948,6 +1955,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2154,6 +2162,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2360,6 +2369,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2588,6 +2598,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -2794,6 +2805,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3000,6 +3012,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3206,6 +3219,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3436,6 +3450,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3642,6 +3657,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -3848,6 +3864,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4054,6 +4071,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4260,6 +4278,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4466,6 +4485,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4672,6 +4692,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -4878,6 +4899,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -5102,6 +5124,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -5308,6 +5331,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -5534,6 +5558,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -5668,6 +5693,627 @@
             "additionalProperties": false,
             "description": "WES pipeline version/commit string.",
             "properties": {
+                "config": {
+                    "$id": "yaml_artifact",
+                    "$schema": "metaschema/strict_meta_schema.json#",
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "$id": "artifact_core",
+                            "$schema": "metaschema/strict_meta_schema.json#",
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "file_name",
+                                        "object_url",
+                                        "uploaded_timestamp",
+                                        "file_size_bytes",
+                                        "artifact_category",
+                                        "data_format",
+                                        "md5_hash"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "file_name",
+                                        "object_url",
+                                        "uploaded_timestamp",
+                                        "file_size_bytes",
+                                        "artifact_category",
+                                        "data_format",
+                                        "crc32c_hash"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "upload_placeholder"
+                                    ]
+                                }
+                            ],
+                            "description": "Any file artifact associated with a clinical trial.",
+                            "inheritableBase": true,
+                            "properties": {
+                                "artifact_category": {
+                                    "description": "Artifact category.",
+                                    "enum": [
+                                        "Assay Artifact from CIMAC",
+                                        "Pipeline Artifact",
+                                        "Manifest File"
+                                    ],
+                                    "type": "string"
+                                },
+                                "artifact_creator": {
+                                    "description": "The name of the center that created this artifact.",
+                                    "enum": [
+                                        "DFCI",
+                                        "Mount Sinai",
+                                        "Stanford",
+                                        "MD Anderson"
+                                    ],
+                                    "type": "string"
+                                },
+                                "crc32c_hash": {
+                                    "description": "CRC32c Hash of artifact.",
+                                    "type": "string"
+                                },
+                                "data_format": {
+                                    "description": "Data Format.",
+                                    "enum": [
+                                        "FASTA",
+                                        "FASTQ.GZ",
+                                        "VCF.GZ",
+                                        "IMAGE",
+                                        "VCF",
+                                        "CSV",
+                                        "TSV",
+                                        "XLSX",
+                                        "NPX",
+                                        "ELISA",
+                                        "BAM",
+                                        "BAM.BAI",
+                                        "MAF",
+                                        "BINARY",
+                                        "TEXT",
+                                        "ZIP",
+                                        "FCS",
+                                        "GZ",
+                                        "JSON",
+                                        "YAML",
+                                        "[NOT SET]"
+                                    ],
+                                    "type": "string"
+                                },
+                                "file_name": {
+                                    "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                    "description": "The name of the file with extension.",
+                                    "type": "string"
+                                },
+                                "file_size_bytes": {
+                                    "description": "File size in bytes.",
+                                    "type": "integer"
+                                },
+                                "md5_hash": {
+                                    "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                    "type": "string"
+                                },
+                                "object_url": {
+                                    "description": "URL to artifact within Google Bucket.",
+                                    "type": "string"
+                                },
+                                "upload_placeholder": {
+                                    "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                    "description": "A placeholder for when artifact file is being uploaded.",
+                                    "type": "string"
+                                },
+                                "uploaded_timestamp": {
+                                    "description": "Timestamp of when artifact was loaded into the system.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                },
+                                "uploader": {
+                                    "description": "The name of the person uploading the artifact.",
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "description": "UUID of artifact.",
+                                    "type": "string"
+                                },
+                                "visible": {
+                                    "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "title": "Artifact Core",
+                            "type": "object"
+                        }
+                    ],
+                    "description": "Information about a YAML file.",
+                    "mergeStrategy": "objectMerge",
+                    "properties": {
+                        "artifact_category": {
+                            "description": "Artifact category.",
+                            "enum": [
+                                "Assay Artifact from CIMAC",
+                                "Pipeline Artifact",
+                                "Manifest File"
+                            ],
+                            "type": "string"
+                        },
+                        "artifact_creator": {
+                            "description": "The name of the center that created this artifact.",
+                            "enum": [
+                                "DFCI",
+                                "Mount Sinai",
+                                "Stanford",
+                                "MD Anderson"
+                            ],
+                            "type": "string"
+                        },
+                        "crc32c_hash": {
+                            "description": "CRC32c Hash of artifact.",
+                            "type": "string"
+                        },
+                        "data_format": {
+                            "const": "YAML",
+                            "description": "Data format."
+                        },
+                        "file_name": {
+                            "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                            "description": "The name of the file with extension.",
+                            "type": "string"
+                        },
+                        "file_size_bytes": {
+                            "description": "File size in bytes.",
+                            "type": "integer"
+                        },
+                        "md5_hash": {
+                            "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                            "type": "string"
+                        },
+                        "object_url": {
+                            "description": "URL to artifact within Google Bucket.",
+                            "type": "string"
+                        },
+                        "upload_placeholder": {
+                            "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                            "description": "A placeholder for when artifact file is being uploaded.",
+                            "type": "string"
+                        },
+                        "uploaded_timestamp": {
+                            "description": "Timestamp of when artifact was loaded into the system.",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "uploader": {
+                            "description": "The name of the person uploading the artifact.",
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "description": "UUID of artifact.",
+                            "type": "string"
+                        },
+                        "visible": {
+                            "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                            "type": "boolean"
+                        }
+                    },
+                    "title": "YAML Artifact",
+                    "type": "object"
+                },
+                "metasheet": {
+                    "$id": "csv_artifact",
+                    "$schema": "metaschema/strict_meta_schema.json#",
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "$id": "artifact_core",
+                            "$schema": "metaschema/strict_meta_schema.json#",
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "file_name",
+                                        "object_url",
+                                        "uploaded_timestamp",
+                                        "file_size_bytes",
+                                        "artifact_category",
+                                        "data_format",
+                                        "md5_hash"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "file_name",
+                                        "object_url",
+                                        "uploaded_timestamp",
+                                        "file_size_bytes",
+                                        "artifact_category",
+                                        "data_format",
+                                        "crc32c_hash"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "upload_placeholder"
+                                    ]
+                                }
+                            ],
+                            "description": "Any file artifact associated with a clinical trial.",
+                            "inheritableBase": true,
+                            "properties": {
+                                "artifact_category": {
+                                    "description": "Artifact category.",
+                                    "enum": [
+                                        "Assay Artifact from CIMAC",
+                                        "Pipeline Artifact",
+                                        "Manifest File"
+                                    ],
+                                    "type": "string"
+                                },
+                                "artifact_creator": {
+                                    "description": "The name of the center that created this artifact.",
+                                    "enum": [
+                                        "DFCI",
+                                        "Mount Sinai",
+                                        "Stanford",
+                                        "MD Anderson"
+                                    ],
+                                    "type": "string"
+                                },
+                                "crc32c_hash": {
+                                    "description": "CRC32c Hash of artifact.",
+                                    "type": "string"
+                                },
+                                "data_format": {
+                                    "description": "Data Format.",
+                                    "enum": [
+                                        "FASTA",
+                                        "FASTQ.GZ",
+                                        "VCF.GZ",
+                                        "IMAGE",
+                                        "VCF",
+                                        "CSV",
+                                        "TSV",
+                                        "XLSX",
+                                        "NPX",
+                                        "ELISA",
+                                        "BAM",
+                                        "BAM.BAI",
+                                        "MAF",
+                                        "BINARY",
+                                        "TEXT",
+                                        "ZIP",
+                                        "FCS",
+                                        "GZ",
+                                        "JSON",
+                                        "YAML",
+                                        "[NOT SET]"
+                                    ],
+                                    "type": "string"
+                                },
+                                "file_name": {
+                                    "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                    "description": "The name of the file with extension.",
+                                    "type": "string"
+                                },
+                                "file_size_bytes": {
+                                    "description": "File size in bytes.",
+                                    "type": "integer"
+                                },
+                                "md5_hash": {
+                                    "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                    "type": "string"
+                                },
+                                "object_url": {
+                                    "description": "URL to artifact within Google Bucket.",
+                                    "type": "string"
+                                },
+                                "upload_placeholder": {
+                                    "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                    "description": "A placeholder for when artifact file is being uploaded.",
+                                    "type": "string"
+                                },
+                                "uploaded_timestamp": {
+                                    "description": "Timestamp of when artifact was loaded into the system.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                },
+                                "uploader": {
+                                    "description": "The name of the person uploading the artifact.",
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "description": "UUID of artifact.",
+                                    "type": "string"
+                                },
+                                "visible": {
+                                    "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "title": "Artifact Core",
+                            "type": "object"
+                        }
+                    ],
+                    "description": "Information about a comma separated file.",
+                    "mergeStrategy": "objectMerge",
+                    "properties": {
+                        "artifact_category": {
+                            "description": "Artifact category.",
+                            "enum": [
+                                "Assay Artifact from CIMAC",
+                                "Pipeline Artifact",
+                                "Manifest File"
+                            ],
+                            "type": "string"
+                        },
+                        "artifact_creator": {
+                            "description": "The name of the center that created this artifact.",
+                            "enum": [
+                                "DFCI",
+                                "Mount Sinai",
+                                "Stanford",
+                                "MD Anderson"
+                            ],
+                            "type": "string"
+                        },
+                        "crc32c_hash": {
+                            "description": "CRC32c Hash of artifact.",
+                            "type": "string"
+                        },
+                        "data_format": {
+                            "const": "CSV",
+                            "description": "Data format."
+                        },
+                        "file_name": {
+                            "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                            "description": "The name of the file with extension.",
+                            "type": "string"
+                        },
+                        "file_size_bytes": {
+                            "description": "File size in bytes.",
+                            "type": "integer"
+                        },
+                        "md5_hash": {
+                            "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                            "type": "string"
+                        },
+                        "object_url": {
+                            "description": "URL to artifact within Google Bucket.",
+                            "type": "string"
+                        },
+                        "upload_placeholder": {
+                            "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                            "description": "A placeholder for when artifact file is being uploaded.",
+                            "type": "string"
+                        },
+                        "uploaded_timestamp": {
+                            "description": "Timestamp of when artifact was loaded into the system.",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "uploader": {
+                            "description": "The name of the person uploading the artifact.",
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "description": "UUID of artifact.",
+                            "type": "string"
+                        },
+                        "visible": {
+                            "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                            "type": "boolean"
+                        }
+                    },
+                    "title": "CSV Artifact",
+                    "type": "object"
+                },
+                "wes_run_version": {
+                    "$id": "tsv_artifact",
+                    "$schema": "metaschema/strict_meta_schema.json#",
+                    "additionalProperties": false,
+                    "allOf": [
+                        {
+                            "$id": "artifact_core",
+                            "$schema": "metaschema/strict_meta_schema.json#",
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "file_name",
+                                        "object_url",
+                                        "uploaded_timestamp",
+                                        "file_size_bytes",
+                                        "artifact_category",
+                                        "data_format",
+                                        "md5_hash"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "file_name",
+                                        "object_url",
+                                        "uploaded_timestamp",
+                                        "file_size_bytes",
+                                        "artifact_category",
+                                        "data_format",
+                                        "crc32c_hash"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "upload_placeholder"
+                                    ]
+                                }
+                            ],
+                            "description": "Any file artifact associated with a clinical trial.",
+                            "inheritableBase": true,
+                            "properties": {
+                                "artifact_category": {
+                                    "description": "Artifact category.",
+                                    "enum": [
+                                        "Assay Artifact from CIMAC",
+                                        "Pipeline Artifact",
+                                        "Manifest File"
+                                    ],
+                                    "type": "string"
+                                },
+                                "artifact_creator": {
+                                    "description": "The name of the center that created this artifact.",
+                                    "enum": [
+                                        "DFCI",
+                                        "Mount Sinai",
+                                        "Stanford",
+                                        "MD Anderson"
+                                    ],
+                                    "type": "string"
+                                },
+                                "crc32c_hash": {
+                                    "description": "CRC32c Hash of artifact.",
+                                    "type": "string"
+                                },
+                                "data_format": {
+                                    "description": "Data Format.",
+                                    "enum": [
+                                        "FASTA",
+                                        "FASTQ.GZ",
+                                        "VCF.GZ",
+                                        "IMAGE",
+                                        "VCF",
+                                        "CSV",
+                                        "TSV",
+                                        "XLSX",
+                                        "NPX",
+                                        "ELISA",
+                                        "BAM",
+                                        "BAM.BAI",
+                                        "MAF",
+                                        "BINARY",
+                                        "TEXT",
+                                        "ZIP",
+                                        "FCS",
+                                        "GZ",
+                                        "JSON",
+                                        "YAML",
+                                        "[NOT SET]"
+                                    ],
+                                    "type": "string"
+                                },
+                                "file_name": {
+                                    "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                    "description": "The name of the file with extension.",
+                                    "type": "string"
+                                },
+                                "file_size_bytes": {
+                                    "description": "File size in bytes.",
+                                    "type": "integer"
+                                },
+                                "md5_hash": {
+                                    "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                    "type": "string"
+                                },
+                                "object_url": {
+                                    "description": "URL to artifact within Google Bucket.",
+                                    "type": "string"
+                                },
+                                "upload_placeholder": {
+                                    "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                    "description": "A placeholder for when artifact file is being uploaded.",
+                                    "type": "string"
+                                },
+                                "uploaded_timestamp": {
+                                    "description": "Timestamp of when artifact was loaded into the system.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                },
+                                "uploader": {
+                                    "description": "The name of the person uploading the artifact.",
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "description": "UUID of artifact.",
+                                    "type": "string"
+                                },
+                                "visible": {
+                                    "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "title": "Artifact Core",
+                            "type": "object"
+                        }
+                    ],
+                    "description": "Information about a tab Separated file.",
+                    "mergeStrategy": "objectMerge",
+                    "properties": {
+                        "artifact_category": {
+                            "description": "Artifact category.",
+                            "enum": [
+                                "Assay Artifact from CIMAC",
+                                "Pipeline Artifact",
+                                "Manifest File"
+                            ],
+                            "type": "string"
+                        },
+                        "artifact_creator": {
+                            "description": "The name of the center that created this artifact.",
+                            "enum": [
+                                "DFCI",
+                                "Mount Sinai",
+                                "Stanford",
+                                "MD Anderson"
+                            ],
+                            "type": "string"
+                        },
+                        "crc32c_hash": {
+                            "description": "CRC32c Hash of artifact.",
+                            "type": "string"
+                        },
+                        "data_format": {
+                            "const": "TSV",
+                            "description": "Data format."
+                        },
+                        "file_name": {
+                            "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                            "description": "The name of the file with extension.",
+                            "type": "string"
+                        },
+                        "file_size_bytes": {
+                            "description": "File size in bytes.",
+                            "type": "integer"
+                        },
+                        "md5_hash": {
+                            "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                            "type": "string"
+                        },
+                        "object_url": {
+                            "description": "URL to artifact within Google Bucket.",
+                            "type": "string"
+                        },
+                        "upload_placeholder": {
+                            "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                            "description": "A placeholder for when artifact file is being uploaded.",
+                            "type": "string"
+                        },
+                        "uploaded_timestamp": {
+                            "description": "Timestamp of when artifact was loaded into the system.",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "uploader": {
+                            "description": "The name of the person uploading the artifact.",
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "description": "UUID of artifact.",
+                            "type": "string"
+                        },
+                        "visible": {
+                            "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                            "type": "boolean"
+                        }
+                    },
+                    "title": "TSV Artifact",
+                    "type": "object"
+                },
                 "wes_version": {
                     "$id": "text_artifact",
                     "$schema": "metaschema/strict_meta_schema.json#",
@@ -5753,6 +6399,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -5876,7 +6523,10 @@
                 }
             },
             "required": [
-                "wes_version"
+                "wes_version",
+                "config",
+                "wes_run_version",
+                "metasheet"
             ],
             "title": "WES Pipeline Version",
             "type": "object"
@@ -5976,6 +6626,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -6182,6 +6833,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -6388,6 +7040,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -6594,6 +7247,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -6800,6 +7454,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -7006,6 +7661,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -7212,6 +7868,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -7443,6 +8100,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -7649,6 +8307,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -7855,6 +8514,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -8061,6 +8721,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -8291,6 +8952,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -8497,6 +9159,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -8703,6 +9366,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -8909,6 +9573,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -9115,6 +9780,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -9321,6 +9987,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -9527,6 +10194,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -9733,6 +10401,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -9957,6 +10626,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"
@@ -10163,6 +10833,7 @@
                                                 "FCS",
                                                 "GZ",
                                                 "JSON",
+                                                "YAML",
                                                 "[NOT SET]"
                                             ],
                                             "type": "string"

--- a/docs/docs/assays.components.ngs.wes.wes_sample_analysis.html
+++ b/docs/docs/assays.components.ngs.wes.wes_sample_analysis.html
@@ -264,6 +264,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -470,6 +471,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -676,6 +678,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -882,6 +885,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1112,6 +1116,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1318,6 +1323,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1524,6 +1530,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1730,6 +1737,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -1936,6 +1944,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2142,6 +2151,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2348,6 +2358,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2554,6 +2565,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2778,6 +2790,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -2984,6 +2997,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.components.olink.olink_combined.html
+++ b/docs/docs/assays.components.olink.olink_combined.html
@@ -226,6 +226,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.components.olink.olink_entry.html
+++ b/docs/docs/assays.components.olink.olink_entry.html
@@ -657,6 +657,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"
@@ -893,6 +894,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.components.olink.olink_input.html
+++ b/docs/docs/assays.components.olink.olink_input.html
@@ -211,6 +211,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -447,6 +448,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.cytof_assay.html
+++ b/docs/docs/assays.cytof_assay.html
@@ -586,6 +586,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -792,6 +793,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"
@@ -1174,6 +1176,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1380,6 +1383,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1604,6 +1608,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1810,6 +1815,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2016,6 +2022,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2222,6 +2229,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2428,6 +2436,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2634,6 +2643,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -2840,6 +2850,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -3078,6 +3089,7 @@
                                     "FCS",
                                     "GZ",
                                     "JSON",
+                                    "YAML",
                                     "[NOT SET]"
                                 ],
                                 "type": "string"
@@ -3286,6 +3298,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.elisa_assay.html
+++ b/docs/docs/assays.elisa_assay.html
@@ -459,6 +459,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/assays.ihc_assay.html
+++ b/docs/docs/assays.ihc_assay.html
@@ -597,6 +597,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"

--- a/docs/docs/assays.micsss_assay.html
+++ b/docs/docs/assays.micsss_assay.html
@@ -844,6 +844,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1078,6 +1079,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1312,6 +1314,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1564,6 +1567,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1798,6 +1802,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2005,6 +2010,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2212,6 +2218,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -2447,6 +2454,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -2665,6 +2673,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"

--- a/docs/docs/assays.mif_assay.html
+++ b/docs/docs/assays.mif_assay.html
@@ -923,6 +923,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -1142,6 +1143,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -1376,6 +1378,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -1583,6 +1586,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -1790,6 +1794,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -2025,6 +2030,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -2247,6 +2253,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -2481,6 +2488,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -2715,6 +2723,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -2961,6 +2970,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -3195,6 +3205,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -3402,6 +3413,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -3609,6 +3621,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -3843,6 +3856,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -4077,6 +4091,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -4311,6 +4326,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -4550,6 +4566,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -4777,6 +4794,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -4984,6 +5002,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"

--- a/docs/docs/assays.olink_assay.html
+++ b/docs/docs/assays.olink_assay.html
@@ -415,6 +415,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -651,6 +652,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -938,6 +940,7 @@
                                         "FCS",
                                         "GZ",
                                         "JSON",
+                                        "YAML",
                                         "[NOT SET]"
                                     ],
                                     "type": "string"

--- a/docs/docs/assays.rna_assay.html
+++ b/docs/docs/assays.rna_assay.html
@@ -594,6 +594,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -805,6 +806,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1016,6 +1018,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1278,6 +1281,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -1489,6 +1493,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -1700,6 +1705,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"

--- a/docs/docs/assays.wes_assay.html
+++ b/docs/docs/assays.wes_assay.html
@@ -614,6 +614,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -825,6 +826,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1036,6 +1038,7 @@
                                                                 "FCS",
                                                                 "GZ",
                                                                 "JSON",
+                                                                "YAML",
                                                                 "[NOT SET]"
                                                             ],
                                                             "type": "string"
@@ -1292,6 +1295,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -1503,6 +1507,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -1714,6 +1719,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -1939,6 +1945,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2145,6 +2152,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2351,6 +2359,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2557,6 +2566,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2787,6 +2797,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -2993,6 +3004,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3199,6 +3211,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3405,6 +3418,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3611,6 +3625,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -3817,6 +3832,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4023,6 +4039,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4229,6 +4246,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4453,6 +4471,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"
@@ -4659,6 +4678,7 @@
                                                             "FCS",
                                                             "GZ",
                                                             "JSON",
+                                                            "YAML",
                                                             "[NOT SET]"
                                                         ],
                                                         "type": "string"

--- a/docs/docs/clinical_trial.html
+++ b/docs/docs/clinical_trial.html
@@ -1035,6 +1035,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -1241,6 +1242,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -1447,6 +1449,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -1653,6 +1656,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -1859,6 +1863,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -2082,6 +2087,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -2288,6 +2294,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -2494,6 +2501,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -2700,6 +2708,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -2906,6 +2915,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -3112,6 +3122,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -3318,6 +3329,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -3524,6 +3536,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -3730,6 +3743,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -3936,6 +3950,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -4164,6 +4179,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -4370,6 +4386,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -4576,6 +4593,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -4782,6 +4800,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -4988,6 +5007,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -5244,6 +5264,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -5463,6 +5484,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -5669,6 +5691,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -5889,6 +5912,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -6095,6 +6119,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -6314,6 +6339,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -6533,6 +6559,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -6739,6 +6766,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -6945,6 +6973,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -7151,6 +7180,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -7379,6 +7409,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -7585,6 +7616,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -7791,6 +7823,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -7997,6 +8030,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -8227,6 +8261,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -8433,6 +8468,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -8639,6 +8675,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -8845,6 +8882,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9051,6 +9089,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9257,6 +9296,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9463,6 +9503,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9669,6 +9710,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -9893,6 +9935,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -10099,6 +10142,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -10325,6 +10369,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -10459,6 +10504,627 @@
                                         "additionalProperties": false,
                                         "description": "WES pipeline version/commit string.",
                                         "properties": {
+                                            "config": {
+                                                "$id": "yaml_artifact",
+                                                "$schema": "metaschema/strict_meta_schema.json#",
+                                                "additionalProperties": false,
+                                                "allOf": [
+                                                    {
+                                                        "$id": "artifact_core",
+                                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                                        "anyOf": [
+                                                            {
+                                                                "required": [
+                                                                    "file_name",
+                                                                    "object_url",
+                                                                    "uploaded_timestamp",
+                                                                    "file_size_bytes",
+                                                                    "artifact_category",
+                                                                    "data_format",
+                                                                    "md5_hash"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "file_name",
+                                                                    "object_url",
+                                                                    "uploaded_timestamp",
+                                                                    "file_size_bytes",
+                                                                    "artifact_category",
+                                                                    "data_format",
+                                                                    "crc32c_hash"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "upload_placeholder"
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "description": "Any file artifact associated with a clinical trial.",
+                                                        "inheritableBase": true,
+                                                        "properties": {
+                                                            "artifact_category": {
+                                                                "description": "Artifact category.",
+                                                                "enum": [
+                                                                    "Assay Artifact from CIMAC",
+                                                                    "Pipeline Artifact",
+                                                                    "Manifest File"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "artifact_creator": {
+                                                                "description": "The name of the center that created this artifact.",
+                                                                "enum": [
+                                                                    "DFCI",
+                                                                    "Mount Sinai",
+                                                                    "Stanford",
+                                                                    "MD Anderson"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "crc32c_hash": {
+                                                                "description": "CRC32c Hash of artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "data_format": {
+                                                                "description": "Data Format.",
+                                                                "enum": [
+                                                                    "FASTA",
+                                                                    "FASTQ.GZ",
+                                                                    "VCF.GZ",
+                                                                    "IMAGE",
+                                                                    "VCF",
+                                                                    "CSV",
+                                                                    "TSV",
+                                                                    "XLSX",
+                                                                    "NPX",
+                                                                    "ELISA",
+                                                                    "BAM",
+                                                                    "BAM.BAI",
+                                                                    "MAF",
+                                                                    "BINARY",
+                                                                    "TEXT",
+                                                                    "ZIP",
+                                                                    "FCS",
+                                                                    "GZ",
+                                                                    "JSON",
+                                                                    "YAML",
+                                                                    "[NOT SET]"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "file_name": {
+                                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                                "description": "The name of the file with extension.",
+                                                                "type": "string"
+                                                            },
+                                                            "file_size_bytes": {
+                                                                "description": "File size in bytes.",
+                                                                "type": "integer"
+                                                            },
+                                                            "md5_hash": {
+                                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                                "type": "string"
+                                                            },
+                                                            "object_url": {
+                                                                "description": "URL to artifact within Google Bucket.",
+                                                                "type": "string"
+                                                            },
+                                                            "upload_placeholder": {
+                                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                                "type": "string"
+                                                            },
+                                                            "uploaded_timestamp": {
+                                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                                "format": "date-time",
+                                                                "type": "string"
+                                                            },
+                                                            "uploader": {
+                                                                "description": "The name of the person uploading the artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "uuid": {
+                                                                "description": "UUID of artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "visible": {
+                                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "title": "Artifact Core",
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "description": "Information about a YAML file.",
+                                                "mergeStrategy": "objectMerge",
+                                                "properties": {
+                                                    "artifact_category": {
+                                                        "description": "Artifact category.",
+                                                        "enum": [
+                                                            "Assay Artifact from CIMAC",
+                                                            "Pipeline Artifact",
+                                                            "Manifest File"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "artifact_creator": {
+                                                        "description": "The name of the center that created this artifact.",
+                                                        "enum": [
+                                                            "DFCI",
+                                                            "Mount Sinai",
+                                                            "Stanford",
+                                                            "MD Anderson"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "crc32c_hash": {
+                                                        "description": "CRC32c Hash of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "data_format": {
+                                                        "const": "YAML",
+                                                        "description": "Data format."
+                                                    },
+                                                    "file_name": {
+                                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                        "description": "The name of the file with extension.",
+                                                        "type": "string"
+                                                    },
+                                                    "file_size_bytes": {
+                                                        "description": "File size in bytes.",
+                                                        "type": "integer"
+                                                    },
+                                                    "md5_hash": {
+                                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                        "type": "string"
+                                                    },
+                                                    "object_url": {
+                                                        "description": "URL to artifact within Google Bucket.",
+                                                        "type": "string"
+                                                    },
+                                                    "upload_placeholder": {
+                                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                                        "type": "string"
+                                                    },
+                                                    "uploaded_timestamp": {
+                                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "uploader": {
+                                                        "description": "The name of the person uploading the artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "description": "UUID of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "visible": {
+                                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "title": "YAML Artifact",
+                                                "type": "object"
+                                            },
+                                            "metasheet": {
+                                                "$id": "csv_artifact",
+                                                "$schema": "metaschema/strict_meta_schema.json#",
+                                                "additionalProperties": false,
+                                                "allOf": [
+                                                    {
+                                                        "$id": "artifact_core",
+                                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                                        "anyOf": [
+                                                            {
+                                                                "required": [
+                                                                    "file_name",
+                                                                    "object_url",
+                                                                    "uploaded_timestamp",
+                                                                    "file_size_bytes",
+                                                                    "artifact_category",
+                                                                    "data_format",
+                                                                    "md5_hash"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "file_name",
+                                                                    "object_url",
+                                                                    "uploaded_timestamp",
+                                                                    "file_size_bytes",
+                                                                    "artifact_category",
+                                                                    "data_format",
+                                                                    "crc32c_hash"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "upload_placeholder"
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "description": "Any file artifact associated with a clinical trial.",
+                                                        "inheritableBase": true,
+                                                        "properties": {
+                                                            "artifact_category": {
+                                                                "description": "Artifact category.",
+                                                                "enum": [
+                                                                    "Assay Artifact from CIMAC",
+                                                                    "Pipeline Artifact",
+                                                                    "Manifest File"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "artifact_creator": {
+                                                                "description": "The name of the center that created this artifact.",
+                                                                "enum": [
+                                                                    "DFCI",
+                                                                    "Mount Sinai",
+                                                                    "Stanford",
+                                                                    "MD Anderson"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "crc32c_hash": {
+                                                                "description": "CRC32c Hash of artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "data_format": {
+                                                                "description": "Data Format.",
+                                                                "enum": [
+                                                                    "FASTA",
+                                                                    "FASTQ.GZ",
+                                                                    "VCF.GZ",
+                                                                    "IMAGE",
+                                                                    "VCF",
+                                                                    "CSV",
+                                                                    "TSV",
+                                                                    "XLSX",
+                                                                    "NPX",
+                                                                    "ELISA",
+                                                                    "BAM",
+                                                                    "BAM.BAI",
+                                                                    "MAF",
+                                                                    "BINARY",
+                                                                    "TEXT",
+                                                                    "ZIP",
+                                                                    "FCS",
+                                                                    "GZ",
+                                                                    "JSON",
+                                                                    "YAML",
+                                                                    "[NOT SET]"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "file_name": {
+                                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                                "description": "The name of the file with extension.",
+                                                                "type": "string"
+                                                            },
+                                                            "file_size_bytes": {
+                                                                "description": "File size in bytes.",
+                                                                "type": "integer"
+                                                            },
+                                                            "md5_hash": {
+                                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                                "type": "string"
+                                                            },
+                                                            "object_url": {
+                                                                "description": "URL to artifact within Google Bucket.",
+                                                                "type": "string"
+                                                            },
+                                                            "upload_placeholder": {
+                                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                                "type": "string"
+                                                            },
+                                                            "uploaded_timestamp": {
+                                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                                "format": "date-time",
+                                                                "type": "string"
+                                                            },
+                                                            "uploader": {
+                                                                "description": "The name of the person uploading the artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "uuid": {
+                                                                "description": "UUID of artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "visible": {
+                                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "title": "Artifact Core",
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "description": "Information about a comma separated file.",
+                                                "mergeStrategy": "objectMerge",
+                                                "properties": {
+                                                    "artifact_category": {
+                                                        "description": "Artifact category.",
+                                                        "enum": [
+                                                            "Assay Artifact from CIMAC",
+                                                            "Pipeline Artifact",
+                                                            "Manifest File"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "artifact_creator": {
+                                                        "description": "The name of the center that created this artifact.",
+                                                        "enum": [
+                                                            "DFCI",
+                                                            "Mount Sinai",
+                                                            "Stanford",
+                                                            "MD Anderson"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "crc32c_hash": {
+                                                        "description": "CRC32c Hash of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "data_format": {
+                                                        "const": "CSV",
+                                                        "description": "Data format."
+                                                    },
+                                                    "file_name": {
+                                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                        "description": "The name of the file with extension.",
+                                                        "type": "string"
+                                                    },
+                                                    "file_size_bytes": {
+                                                        "description": "File size in bytes.",
+                                                        "type": "integer"
+                                                    },
+                                                    "md5_hash": {
+                                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                        "type": "string"
+                                                    },
+                                                    "object_url": {
+                                                        "description": "URL to artifact within Google Bucket.",
+                                                        "type": "string"
+                                                    },
+                                                    "upload_placeholder": {
+                                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                                        "type": "string"
+                                                    },
+                                                    "uploaded_timestamp": {
+                                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "uploader": {
+                                                        "description": "The name of the person uploading the artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "description": "UUID of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "visible": {
+                                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "title": "CSV Artifact",
+                                                "type": "object"
+                                            },
+                                            "wes_run_version": {
+                                                "$id": "tsv_artifact",
+                                                "$schema": "metaschema/strict_meta_schema.json#",
+                                                "additionalProperties": false,
+                                                "allOf": [
+                                                    {
+                                                        "$id": "artifact_core",
+                                                        "$schema": "metaschema/strict_meta_schema.json#",
+                                                        "anyOf": [
+                                                            {
+                                                                "required": [
+                                                                    "file_name",
+                                                                    "object_url",
+                                                                    "uploaded_timestamp",
+                                                                    "file_size_bytes",
+                                                                    "artifact_category",
+                                                                    "data_format",
+                                                                    "md5_hash"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "file_name",
+                                                                    "object_url",
+                                                                    "uploaded_timestamp",
+                                                                    "file_size_bytes",
+                                                                    "artifact_category",
+                                                                    "data_format",
+                                                                    "crc32c_hash"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "upload_placeholder"
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "description": "Any file artifact associated with a clinical trial.",
+                                                        "inheritableBase": true,
+                                                        "properties": {
+                                                            "artifact_category": {
+                                                                "description": "Artifact category.",
+                                                                "enum": [
+                                                                    "Assay Artifact from CIMAC",
+                                                                    "Pipeline Artifact",
+                                                                    "Manifest File"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "artifact_creator": {
+                                                                "description": "The name of the center that created this artifact.",
+                                                                "enum": [
+                                                                    "DFCI",
+                                                                    "Mount Sinai",
+                                                                    "Stanford",
+                                                                    "MD Anderson"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "crc32c_hash": {
+                                                                "description": "CRC32c Hash of artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "data_format": {
+                                                                "description": "Data Format.",
+                                                                "enum": [
+                                                                    "FASTA",
+                                                                    "FASTQ.GZ",
+                                                                    "VCF.GZ",
+                                                                    "IMAGE",
+                                                                    "VCF",
+                                                                    "CSV",
+                                                                    "TSV",
+                                                                    "XLSX",
+                                                                    "NPX",
+                                                                    "ELISA",
+                                                                    "BAM",
+                                                                    "BAM.BAI",
+                                                                    "MAF",
+                                                                    "BINARY",
+                                                                    "TEXT",
+                                                                    "ZIP",
+                                                                    "FCS",
+                                                                    "GZ",
+                                                                    "JSON",
+                                                                    "YAML",
+                                                                    "[NOT SET]"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "file_name": {
+                                                                "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                                "description": "The name of the file with extension.",
+                                                                "type": "string"
+                                                            },
+                                                            "file_size_bytes": {
+                                                                "description": "File size in bytes.",
+                                                                "type": "integer"
+                                                            },
+                                                            "md5_hash": {
+                                                                "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                                "type": "string"
+                                                            },
+                                                            "object_url": {
+                                                                "description": "URL to artifact within Google Bucket.",
+                                                                "type": "string"
+                                                            },
+                                                            "upload_placeholder": {
+                                                                "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                                "description": "A placeholder for when artifact file is being uploaded.",
+                                                                "type": "string"
+                                                            },
+                                                            "uploaded_timestamp": {
+                                                                "description": "Timestamp of when artifact was loaded into the system.",
+                                                                "format": "date-time",
+                                                                "type": "string"
+                                                            },
+                                                            "uploader": {
+                                                                "description": "The name of the person uploading the artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "uuid": {
+                                                                "description": "UUID of artifact.",
+                                                                "type": "string"
+                                                            },
+                                                            "visible": {
+                                                                "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "title": "Artifact Core",
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "description": "Information about a tab Separated file.",
+                                                "mergeStrategy": "objectMerge",
+                                                "properties": {
+                                                    "artifact_category": {
+                                                        "description": "Artifact category.",
+                                                        "enum": [
+                                                            "Assay Artifact from CIMAC",
+                                                            "Pipeline Artifact",
+                                                            "Manifest File"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "artifact_creator": {
+                                                        "description": "The name of the center that created this artifact.",
+                                                        "enum": [
+                                                            "DFCI",
+                                                            "Mount Sinai",
+                                                            "Stanford",
+                                                            "MD Anderson"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "crc32c_hash": {
+                                                        "description": "CRC32c Hash of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "data_format": {
+                                                        "const": "TSV",
+                                                        "description": "Data format."
+                                                    },
+                                                    "file_name": {
+                                                        "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+                                                        "description": "The name of the file with extension.",
+                                                        "type": "string"
+                                                    },
+                                                    "file_size_bytes": {
+                                                        "description": "File size in bytes.",
+                                                        "type": "integer"
+                                                    },
+                                                    "md5_hash": {
+                                                        "description": "MD5 Hash of artifact. Not available for composite GCS objects.",
+                                                        "type": "string"
+                                                    },
+                                                    "object_url": {
+                                                        "description": "URL to artifact within Google Bucket.",
+                                                        "type": "string"
+                                                    },
+                                                    "upload_placeholder": {
+                                                        "$comment": "It might be something like random uuid or `upload_job_id` to help trace everything back.",
+                                                        "description": "A placeholder for when artifact file is being uploaded.",
+                                                        "type": "string"
+                                                    },
+                                                    "uploaded_timestamp": {
+                                                        "description": "Timestamp of when artifact was loaded into the system.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "uploader": {
+                                                        "description": "The name of the person uploading the artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "uuid": {
+                                                        "description": "UUID of artifact.",
+                                                        "type": "string"
+                                                    },
+                                                    "visible": {
+                                                        "description": "Indicates if the artifact is visible.  If set to false, the artifact is effectively deleted.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "title": "TSV Artifact",
+                                                "type": "object"
+                                            },
                                             "wes_version": {
                                                 "$id": "text_artifact",
                                                 "$schema": "metaschema/strict_meta_schema.json#",
@@ -10544,6 +11210,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -10667,7 +11334,10 @@
                                             }
                                         },
                                         "required": [
-                                            "wes_version"
+                                            "wes_version",
+                                            "config",
+                                            "wes_run_version",
+                                            "metasheet"
                                         ],
                                         "title": "WES Pipeline Version",
                                         "type": "object"
@@ -10767,6 +11437,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -10973,6 +11644,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -11179,6 +11851,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -11385,6 +12058,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -11591,6 +12265,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -11797,6 +12472,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -12003,6 +12679,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -12234,6 +12911,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -12440,6 +13118,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -12646,6 +13325,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -12852,6 +13532,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -13082,6 +13763,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -13288,6 +13970,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -13494,6 +14177,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -13700,6 +14384,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -13906,6 +14591,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14112,6 +14798,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14318,6 +15005,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14524,6 +15212,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14748,6 +15437,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -14954,6 +15644,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -15254,6 +15945,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -15460,6 +16152,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -15842,6 +16535,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16048,6 +16742,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16272,6 +16967,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16478,6 +17174,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16684,6 +17381,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -16890,6 +17588,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17096,6 +17795,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17302,6 +18002,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17508,6 +18209,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -17746,6 +18448,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -17954,6 +18657,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -18329,6 +19033,7 @@
                                                     "FCS",
                                                     "GZ",
                                                     "JSON",
+                                                    "YAML",
                                                     "[NOT SET]"
                                                 ],
                                                 "type": "string"
@@ -18785,6 +19490,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -19429,6 +20135,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -19663,6 +20370,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -19897,6 +20605,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -20149,6 +20858,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -20383,6 +21093,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -20590,6 +21301,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -20797,6 +21509,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -21032,6 +21745,7 @@
                                                                                         "FCS",
                                                                                         "GZ",
                                                                                         "JSON",
+                                                                                        "YAML",
                                                                                         "[NOT SET]"
                                                                                     ],
                                                                                     "type": "string"
@@ -21250,6 +21964,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -21825,6 +22540,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -22044,6 +22760,7 @@
                                                                                             "FCS",
                                                                                             "GZ",
                                                                                             "JSON",
+                                                                                            "YAML",
                                                                                             "[NOT SET]"
                                                                                         ],
                                                                                         "type": "string"
@@ -22278,6 +22995,7 @@
                                                                                             "FCS",
                                                                                             "GZ",
                                                                                             "JSON",
+                                                                                            "YAML",
                                                                                             "[NOT SET]"
                                                                                         ],
                                                                                         "type": "string"
@@ -22485,6 +23203,7 @@
                                                                                             "FCS",
                                                                                             "GZ",
                                                                                             "JSON",
+                                                                                            "YAML",
                                                                                             "[NOT SET]"
                                                                                         ],
                                                                                         "type": "string"
@@ -22692,6 +23411,7 @@
                                                                                             "FCS",
                                                                                             "GZ",
                                                                                             "JSON",
+                                                                                            "YAML",
                                                                                             "[NOT SET]"
                                                                                         ],
                                                                                         "type": "string"
@@ -22927,6 +23647,7 @@
                                                                                                 "FCS",
                                                                                                 "GZ",
                                                                                                 "JSON",
+                                                                                                "YAML",
                                                                                                 "[NOT SET]"
                                                                                             ],
                                                                                             "type": "string"
@@ -23149,6 +23870,7 @@
                                                                                             "FCS",
                                                                                             "GZ",
                                                                                             "JSON",
+                                                                                            "YAML",
                                                                                             "[NOT SET]"
                                                                                         ],
                                                                                         "type": "string"
@@ -23383,6 +24105,7 @@
                                                                                             "FCS",
                                                                                             "GZ",
                                                                                             "JSON",
+                                                                                            "YAML",
                                                                                             "[NOT SET]"
                                                                                         ],
                                                                                         "type": "string"
@@ -23617,6 +24340,7 @@
                                                                                             "FCS",
                                                                                             "GZ",
                                                                                             "JSON",
+                                                                                            "YAML",
                                                                                             "[NOT SET]"
                                                                                         ],
                                                                                         "type": "string"
@@ -23863,6 +24587,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -24097,6 +24822,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -24304,6 +25030,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -24511,6 +25238,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -24745,6 +25473,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -24979,6 +25708,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -25213,6 +25943,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -25452,6 +26183,7 @@
                                                                                         "FCS",
                                                                                         "GZ",
                                                                                         "JSON",
+                                                                                        "YAML",
                                                                                         "[NOT SET]"
                                                                                     ],
                                                                                     "type": "string"
@@ -25679,6 +26411,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -25886,6 +26619,7 @@
                                                                         "FCS",
                                                                         "GZ",
                                                                         "JSON",
+                                                                        "YAML",
                                                                         "[NOT SET]"
                                                                     ],
                                                                     "type": "string"
@@ -26246,6 +26980,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -26482,6 +27217,7 @@
                                                                     "FCS",
                                                                     "GZ",
                                                                     "JSON",
+                                                                    "YAML",
                                                                     "[NOT SET]"
                                                                 ],
                                                                 "type": "string"
@@ -26769,6 +27505,7 @@
                                                         "FCS",
                                                         "GZ",
                                                         "JSON",
+                                                        "YAML",
                                                         "[NOT SET]"
                                                     ],
                                                     "type": "string"
@@ -27186,6 +27923,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -27397,6 +28135,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -27608,6 +28347,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -27870,6 +28610,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -28081,6 +28822,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -28292,6 +29034,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -28715,6 +29458,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -28926,6 +29670,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -29137,6 +29882,7 @@
                                                                                     "FCS",
                                                                                     "GZ",
                                                                                     "JSON",
+                                                                                    "YAML",
                                                                                     "[NOT SET]"
                                                                                 ],
                                                                                 "type": "string"
@@ -29393,6 +30139,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -29604,6 +30351,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -29815,6 +30563,7 @@
                                                                             "FCS",
                                                                             "GZ",
                                                                             "JSON",
+                                                                            "YAML",
                                                                             "[NOT SET]"
                                                                         ],
                                                                         "type": "string"
@@ -30040,6 +30789,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -30246,6 +30996,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -30452,6 +31203,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -30658,6 +31410,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -30888,6 +31641,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -31094,6 +31848,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -31300,6 +32055,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -31506,6 +32262,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -31712,6 +32469,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -31918,6 +32676,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -32124,6 +32883,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -32330,6 +33090,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -32554,6 +33315,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -32760,6 +33522,7 @@
                                                                                 "FCS",
                                                                                 "GZ",
                                                                                 "JSON",
+                                                                                "YAML",
                                                                                 "[NOT SET]"
                                                                             ],
                                                                             "type": "string"
@@ -33759,6 +34522,7 @@
                                 "FCS",
                                 "GZ",
                                 "JSON",
+                                "YAML",
                                 "[NOT SET]"
                             ],
                             "type": "string"

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -181,6 +181,13 @@
                 
                 <tr>
                     
+                        <td width=25%><a href='artifacts.artifact_yaml.html'>YAML Artifact</a></td>
+                    
+                    <td>Information about a YAML file.</td>
+                </tr>
+                
+                <tr>
+                    
                         <td width=25%><a href='artifacts.artifact_core.html'>Artifact Core</a></td>
                     
                     <td>Any file artifact associated with a clinical trial.</td>

--- a/docs/docs/templates.metadata.ihc_template.html
+++ b/docs/docs/templates.metadata.ihc_template.html
@@ -457,6 +457,49 @@
         
     </table>
     
+      <h5 class="text-muted">Marker call</h4>
+      
+    
+        
+    
+
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Property</th>
+            <th>Description</th>
+            <th>Data Type</th>
+        </tr>
+        </thead>
+        
+            
+        
+        
+            
+                <tr>
+    <td>
+        
+            <span id="marker positive">
+                marker positive
+            </span>
+            
+        
+    </td>
+    <td width=55%>
+        
+            Indicates whether the marker is considered positive by clinical trial guidelines (if applicable).
+        
+    </td>
+    <td>
+        
+            <a href="assays.components.imaging.ihc_entry.html#marker_positive">assays.components.imaging.ihc_entry#marker_positive</a>
+        
+    </td>
+</tr>
+            
+        
+    </table>
+    
       <h5 class="text-muted">Chromogenic IHC (please specify one score/metric)</h4>
       
     
@@ -488,31 +531,6 @@
         
             
         
-            
-        
-        
-            
-                <tr>
-    <td>
-        
-            <span id="marker positive">
-                marker positive
-            </span>
-            
-        
-    </td>
-    <td width=55%>
-        
-            Indicates whether the marker is considered positive by clinical trial guidelines (if applicable).
-        
-    </td>
-    <td>
-        
-            <a href="assays.components.imaging.ihc_entry.html#marker_positive">assays.components.imaging.ihc_entry#marker_positive</a>
-        
-    </td>
-</tr>
-            
         
             
                 <tr>

--- a/docs/docs/templates.metadata.mif_template.html
+++ b/docs/docs/templates.metadata.mif_template.html
@@ -447,7 +447,7 @@
     </td>
     <td width=55%>
         
-            A comma-separated list of paths to files on a user's computer.
+            Comma separated list of score_data.txt files from inform export, will be usually just one.
         
     </td>
     <td>
@@ -470,7 +470,7 @@
     </td>
     <td width=55%>
         
-            Path on a user's computer to an InForm export directory with ROI's export prefix
+            Path on a user's computer to an InForm export directory with ROI's export prefix. From that upload tool will look for binary_seg_maps.tif, cell_seg_data.txt, cell_seg_data_summary.txt, phenotype_map.tif, composite_image.tif, and component_data.tif
         
     </td>
     <td>

--- a/tests/prism/cidc_test_data/analysis_data.py
+++ b/tests/prism/cidc_test_data/analysis_data.py
@@ -158,6 +158,9 @@ def wes_analysis() -> PrismTestData:
                             "wes_run_version": {
                                 "upload_placeholder": "c47271fb-e2c7-5436-cafe-5cf84bc72bf4"
                             },
+                            "metasheet": {
+                                "upload_placeholder": "xyz271fb-e2c7-5436-cafe-5cf84bc72bf4"
+                            },
                         },
                         "normal": {
                             "cimac_id": "CTTTPP111.00",
@@ -339,6 +342,9 @@ def wes_analysis() -> PrismTestData:
                             "wes_run_version": {
                                 "upload_placeholder": "56824763-fb9f-58b4-c7c4-8175759933f4"
                             },
+                            "metasheet": {
+                                "upload_placeholder": "xyz24763-fb9f-58b4-c7c4-8175759933f4"
+                            },
                         },
                         "normal": {
                             "cimac_id": "CTTTPP121.00",
@@ -519,6 +525,12 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/report/config.yaml",
             gs_key="test_prism_trial_id/wes/run_1/analysis/config.yaml",
             upload_placeholder="abc271fb-d2c7-4436-bafe-4cf84bc72bf4",
+            metadata_availability=None,
+        ),
+        LocalFileUploadEntry(
+            local_path="analysis/report/metasheet.csv",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/metasheet.csv",
+            upload_placeholder="xyz24763-fb9f-58b4-c7c4-8175759933f4",
             metadata_availability=None,
         ),
         LocalFileUploadEntry(
@@ -807,6 +819,12 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/report/config.yaml",
             gs_key="test_prism_trial_id/wes/run_2/analysis/config.yaml",
             upload_placeholder="abc24763-fb9f-48b4-b7c4-7175759933f5",
+            metadata_availability=None,
+        ),
+        LocalFileUploadEntry(
+            local_path="analysis/report/metasheet.csv",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/metasheet.csv",
+            upload_placeholder="xyz271fb-e2c7-5436-cafe-5cf84bc72bf4",
             metadata_availability=None,
         ),
         LocalFileUploadEntry(

--- a/tests/prism/cidc_test_data/analysis_data.py
+++ b/tests/prism/cidc_test_data/analysis_data.py
@@ -151,7 +151,10 @@ def wes_analysis() -> PrismTestData:
                         "report": {
                             "wes_version": {
                                 "upload_placeholder": "b47271fb-d2c7-4436-bafe-4cf84bc72bf4"
-                            }
+                            },
+                            "wes_run_version": {
+                                "upload_placeholder": "c47271fb-e2c7-5436-cafe-5cf84bc72bf4"
+                            },
                         },
                         "normal": {
                             "cimac_id": "CTTTPP111.00",
@@ -326,7 +329,10 @@ def wes_analysis() -> PrismTestData:
                         "report": {
                             "wes_version": {
                                 "upload_placeholder": "46824763-fb9f-48b4-b7c4-7175759933f4"
-                            }
+                            },
+                            "wes_run_version": {
+                                "upload_placeholder": "56824763-fb9f-58b4-c7c4-8175759933f4"
+                            },
                         },
                         "normal": {
                             "cimac_id": "CTTTPP121.00",
@@ -501,6 +507,12 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/report/wes_version.txt",
             gs_key="test_prism_trial_id/wes/run_1/analysis/wes_version.txt",
             upload_placeholder="b47271fb-d2c7-4436-bafe-4cf84bc72bf4",
+            metadata_availability=None,
+        ),
+        LocalFileUploadEntry(
+            local_path="analysis/report/wes_meta/02_wes_run_version.tsv",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/wes_run_version.tsv",
+            upload_placeholder="c47271fb-e2c7-5436-cafe-5cf84bc72bf4",
             metadata_availability=None,
         ),
         LocalFileUploadEntry(
@@ -777,6 +789,12 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/report/wes_version.txt",
             gs_key="test_prism_trial_id/wes/run_2/analysis/wes_version.txt",
             upload_placeholder="46824763-fb9f-48b4-b7c4-7175759933f4",
+            metadata_availability=None,
+        ),
+        LocalFileUploadEntry(
+            local_path="analysis/report/wes_meta/02_wes_run_version.tsv",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/wes_run_version.tsv",
+            upload_placeholder="56824763-fb9f-58b4-c7c4-8175759933f4",
             metadata_availability=None,
         ),
         LocalFileUploadEntry(

--- a/tests/prism/cidc_test_data/analysis_data.py
+++ b/tests/prism/cidc_test_data/analysis_data.py
@@ -152,6 +152,9 @@ def wes_analysis() -> PrismTestData:
                             "wes_version": {
                                 "upload_placeholder": "b47271fb-d2c7-4436-bafe-4cf84bc72bf4"
                             },
+                            "config": {
+                                "upload_placeholder": "abc271fb-d2c7-4436-bafe-4cf84bc72bf4"
+                            },
                             "wes_run_version": {
                                 "upload_placeholder": "c47271fb-e2c7-5436-cafe-5cf84bc72bf4"
                             },
@@ -330,6 +333,9 @@ def wes_analysis() -> PrismTestData:
                             "wes_version": {
                                 "upload_placeholder": "46824763-fb9f-48b4-b7c4-7175759933f4"
                             },
+                            "config": {
+                                "upload_placeholder": "abc24763-fb9f-48b4-b7c4-7175759933f5"
+                            },
                             "wes_run_version": {
                                 "upload_placeholder": "56824763-fb9f-58b4-c7c4-8175759933f4"
                             },
@@ -507,6 +513,12 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/report/wes_version.txt",
             gs_key="test_prism_trial_id/wes/run_1/analysis/wes_version.txt",
             upload_placeholder="b47271fb-d2c7-4436-bafe-4cf84bc72bf4",
+            metadata_availability=None,
+        ),
+        LocalFileUploadEntry(
+            local_path="analysis/report/config.yaml",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/config.yaml",
+            upload_placeholder="abc271fb-d2c7-4436-bafe-4cf84bc72bf4",
             metadata_availability=None,
         ),
         LocalFileUploadEntry(
@@ -789,6 +801,12 @@ def wes_analysis() -> PrismTestData:
             local_path="analysis/report/wes_version.txt",
             gs_key="test_prism_trial_id/wes/run_2/analysis/wes_version.txt",
             upload_placeholder="46824763-fb9f-48b4-b7c4-7175759933f4",
+            metadata_availability=None,
+        ),
+        LocalFileUploadEntry(
+            local_path="analysis/report/config.yaml",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/config.yaml",
+            upload_placeholder="abc24763-fb9f-48b4-b7c4-7175759933f5",
             metadata_availability=None,
         ),
         LocalFileUploadEntry(


### PR DESCRIPTION
This PR adds three 'versioning' files to WES analysis, requested [here](https://github.com/CIMAC-CIDC/cidc-ngs-pipeline-api/pull/7) :

- `analysis/report/wes_meta/02_wes_run_version.tsv`
- `analysis/report/config.yaml`
- `analysis/report/metasheet.csv`
