### PR TITLE
Create test-and-publish.yml as a replacement for .travis.yml

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Report test coverage
         run: |
           coverage xml
-          ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT
+          ./cc-test-reporter after-build -t coverage.py --exit-code 0
       - name: Publish package to PyPI
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1,0 +1,45 @@
+name: test-and-publish
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.dev.txt
+          pip install pytest-cov
+      - name: Check code format with black
+        run: |
+          black --check cidc_schemas tests docs --target-version=py37
+      - name: Setup codeclimate test coverage reporter
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+      - name: Test with pytest
+        run: |
+          pytest --cov=cidc_schemas -v --benchmark-group-by=func
+      - name: Report test coverage
+        run: |
+          coverage xml
+          ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT
+      - name: Publish package to PyPI
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          skip_existing: true
+          user: jlurye-ksg
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -33,6 +33,8 @@ jobs:
         run: |
           pytest --cov=cidc_schemas -v --benchmark-group-by=func
       - name: Report test coverage
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: |
           coverage xml
           ./cc-test-reporter after-build -t coverage.py --exit-code 0


### PR DESCRIPTION
`PYPI_PASSWORD` is configured as an *organization-level secret* in the CIMAC-CIDC GitHub organization settings, because it's the same for all repos that use it.

`CC_TEST_REPORTER_ID` is a *repository-level secret*, because it's specific to this repo.