### PR TITLE
Relax mIF im3 and phenotype_map requirements

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.23.12"
+__version__ = "0.23.13"

--- a/cidc_schemas/schemas/assays/components/imaging/mif_roi.json
+++ b/cidc_schemas/schemas/assays/components/imaging/mif_roi.json
@@ -29,7 +29,6 @@
   "mergeStrategy": "objectMerge",
   "required": [
     "roi_id",
-    "im3",
     "exports"
   ]
 }

--- a/cidc_schemas/schemas/assays/components/mapping.json
+++ b/cidc_schemas/schemas/assays/components/mapping.json
@@ -44,6 +44,5 @@
         "$ref": "artifacts/artifact_text.json"
       }
     }
-  },
-  "required": ["phenotype_map"]
+  }
 }


### PR DESCRIPTION
Needed for S1400I part B (no phenotype_map's) and 10021 (no im3's)