### PR TITLE
Make data_format and file_name optional instead of removing them

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.1"
+__version__ = "0.24.17"

--- a/cidc_schemas/schemas/artifacts/artifact_bam.json
+++ b/cidc_schemas/schemas/artifacts/artifact_bam.json
@@ -6,6 +6,10 @@
   "description": "Information about a BAM file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "BAM"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_bam_bai.json
+++ b/cidc_schemas/schemas/artifacts/artifact_bam_bai.json
@@ -6,6 +6,10 @@
   "description": "Information about a Bam index file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "BAM.BAI"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_binary.json
+++ b/cidc_schemas/schemas/artifacts/artifact_binary.json
@@ -6,6 +6,10 @@
   "description": "Information about a binary file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "BINARY"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_clinical_xlsx.json
+++ b/cidc_schemas/schemas/artifacts/artifact_clinical_xlsx.json
@@ -18,6 +18,10 @@
         "$ref": "participant.json#properties/cimac_participant_id"
       }
     },
+    "data_format": {
+      "description": "Data format.",
+      "const": "XLSX"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -26,6 +30,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_core.json
+++ b/cidc_schemas/schemas/artifacts/artifact_core.json
@@ -24,6 +24,11 @@
       "description": "UUID of artifact.",
       "type": "string"
     },
+    "file_name": {
+      "$comment": "This supposedly get generated from 'gcs_uri_format' field in template schema def.",
+      "description": "The name of the file with extension.",
+      "type": "string"
+    },
     "object_url": {
       "description": "URL to artifact within Google Bucket.",
       "type": "string"
@@ -56,6 +61,34 @@
         "Assay Artifact from CIMAC",
         "Pipeline Artifact",
         "Manifest File"
+      ]
+    },
+    "data_format": {
+      "description": "Data Format.",
+      "type": "string",
+      "enum": [
+        "FASTA",
+        "FASTQ.GZ",
+        "VCF.GZ",
+        "IMAGE",
+        "VCF",
+        "CSV",
+        "TSV",
+        "XLSX",
+        "NPX",
+        "ELISA",
+        "BAM",
+        "BAM.BAI",
+        "MAF",
+        "BINARY",
+        "TEXT",
+        "ZIP",
+        "FCS",
+        "GZ",
+        "RCC",
+        "JSON",
+        "YAML",
+        "[NOT SET]"
       ]
     },
     "facet_group": {

--- a/cidc_schemas/schemas/artifacts/artifact_csv.json
+++ b/cidc_schemas/schemas/artifacts/artifact_csv.json
@@ -6,6 +6,10 @@
   "description": "Information about a comma separated file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "CSV"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_elisa_xlsx.json
+++ b/cidc_schemas/schemas/artifacts/artifact_elisa_xlsx.json
@@ -19,6 +19,10 @@
         "$ref": "sample.json#properties/cimac_id"
       }
     },
+    "data_format": {
+      "description": "Data format.",
+      "const": "ELISA"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -27,6 +31,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_fastq_gz.json
+++ b/cidc_schemas/schemas/artifacts/artifact_fastq_gz.json
@@ -6,6 +6,10 @@
   "description": "Information about a Gzipped FASTQ file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "FASTQ.GZ"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_fcs.json
+++ b/cidc_schemas/schemas/artifacts/artifact_fcs.json
@@ -6,6 +6,10 @@
   "description": "Information about a FCS file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "FCS"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_gz.json
+++ b/cidc_schemas/schemas/artifacts/artifact_gz.json
@@ -6,6 +6,10 @@
   "description": "Information about a GZ file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "GZ"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_image.json
+++ b/cidc_schemas/schemas/artifacts/artifact_image.json
@@ -19,7 +19,10 @@
       "$comment": "3 for RGB imagery, 1 for grayscale imagery.",
       "type": "integer"
     },
-
+    "data_format": {
+      "description": "Data format.",
+      "const": "IMAGE"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -28,6 +31,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_json.json
+++ b/cidc_schemas/schemas/artifacts/artifact_json.json
@@ -6,6 +6,10 @@
   "description": "Information about a JSON file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "JSON"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_maf.json
+++ b/cidc_schemas/schemas/artifacts/artifact_maf.json
@@ -6,6 +6,10 @@
   "description": "Information about a MAF file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "MAF"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_npx.json
+++ b/cidc_schemas/schemas/artifacts/artifact_npx.json
@@ -18,7 +18,10 @@
         "$ref": "sample.json#properties/cimac_id"
       }
     },
-
+    "data_format": {
+      "description": "Data format.",
+      "const": "NPX"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -27,6 +30,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_rcc.json
+++ b/cidc_schemas/schemas/artifacts/artifact_rcc.json
@@ -6,6 +6,10 @@
   "description": "Information about a Nanostring output file. XML-formatted comma-separated tables",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "RCC"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_tbi.json
+++ b/cidc_schemas/schemas/artifacts/artifact_tbi.json
@@ -6,6 +6,10 @@
   "description": "Information about a Tabix index file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "TBI"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_text.json
+++ b/cidc_schemas/schemas/artifacts/artifact_text.json
@@ -6,6 +6,10 @@
   "description": "Information about a text file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "TEXT"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_tsv.json
+++ b/cidc_schemas/schemas/artifacts/artifact_tsv.json
@@ -6,6 +6,10 @@
   "description": "Information about a tab Separated file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "TSV"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_vcf.json
+++ b/cidc_schemas/schemas/artifacts/artifact_vcf.json
@@ -6,6 +6,10 @@
   "description": "Information about a VCF file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "VCF"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_vcf_gz.json
+++ b/cidc_schemas/schemas/artifacts/artifact_vcf_gz.json
@@ -6,6 +6,10 @@
   "description": "Information about a Gzipped VCF file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "VCF.GZ"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_xlsx.json
+++ b/cidc_schemas/schemas/artifacts/artifact_xlsx.json
@@ -6,6 +6,10 @@
   "description": "Information about an XLSX file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "XLSX"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_yaml.json
+++ b/cidc_schemas/schemas/artifacts/artifact_yaml.json
@@ -6,6 +6,10 @@
   "description": "Information about a YAML file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "YAML"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/cidc_schemas/schemas/artifacts/artifact_zip.json
+++ b/cidc_schemas/schemas/artifacts/artifact_zip.json
@@ -6,6 +6,10 @@
   "description": "Information about a ZIP file.",
   "additionalProperties": false,
   "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "ZIP"
+    },
     "upload_placeholder": {
       "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
     },
@@ -14,6 +18,9 @@
     },
     "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
     "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
     "object_url": {
       "$ref": "artifacts/artifact_core.json#properties/object_url"
     },

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -16,7 +16,9 @@ BASE_OBJ = {
     "artifact_category": "Manifest File",
     "artifact_creator": "DFCI",
     "object_url": "dummy",
+    "file_name": "dummy.txt",
     "file_size_bytes": 1,
+    "data_format": "FASTA",
     "crc32c_hash": "dummy",
     "uploaded_timestamp": "dummy",
     "uuid": "dummy",
@@ -42,6 +44,7 @@ def test_upload_placeholder_oneOf_required():
         "oneOf": [
           {
             "required": [
+              "file_name",
               "object_url",
               "uploaded_timestamp",
               "file_size_bytes",
@@ -59,10 +62,12 @@ def test_upload_placeholder_oneOf_required():
 
     # create validator assert schemas are valid.
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "CSV"
     at_validator = _fetch_validator("core")
     at_validator.validate(obj)
 
     # assert we can fail it.
+    del obj["file_name"]
     del obj["object_url"]
     del obj["uploaded_timestamp"]
     del obj["file_size_bytes"]
@@ -83,6 +88,7 @@ def test_text():
 
     # create validator assert schemas are valid.
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "TEXT"
     at_validator = _fetch_validator("text")
     at_validator.validate(obj)
 
@@ -99,6 +105,7 @@ def test_image():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "IMAGE"
     obj["height"] = 128
     obj["width"] = 128
     obj["channels"] = 8
@@ -112,6 +119,7 @@ def test_binary():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "BINARY"
     at_validator.validate(obj)
 
 
@@ -122,6 +130,7 @@ def test_csv():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "CSV"
     at_validator.validate(obj)
 
 
@@ -132,6 +141,7 @@ def test_fcs():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "FCS"
     at_validator.validate(obj)
 
 
@@ -142,6 +152,7 @@ def test_zip():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "ZIP"
     at_validator.validate(obj)
 
 
@@ -152,6 +163,7 @@ def test_npx():
 
     # create a dummy info
     obj = BASE_OBJ.copy()
+    obj["data_format"] = "NPX"
 
     # should fail
     with pytest.raises(jsonschema.ValidationError):

--- a/tests/test_assays.py
+++ b/tests/test_assays.py
@@ -13,7 +13,9 @@ ARTIFACT_OBJ = {
     "artifact_category": "Manifest File",
     "artifact_creator": "DFCI",
     "object_url": "dummy",
+    "file_name": "dummy.txt",
     "file_size_bytes": 1,
+    "data_format": "FASTA",
     "crc32c_hash": "dummy",
     "uploaded_timestamp": "dummy",
     "uploader": "dummy",
@@ -68,7 +70,9 @@ def test_wes_fastq():
 
     # create the wes object
     r1 = ARTIFACT_OBJ.copy()
+    r1["data_format"] = "FASTQ.GZ"
     r2 = ARTIFACT_OBJ.copy()
+    r2["data_format"] = "FASTQ.GZ"
     record = {
         "cimac_id": "CTTTPPPSA.00",
         "files": {"r1": [r1], "r2": [r2]},
@@ -99,6 +103,7 @@ def test_wes_bam():
 
     # create the wes object
     bam = ARTIFACT_OBJ.copy()
+    bam["data_format"] = "BAM"
     record = {
         "cimac_id": "CTTTPPPSA.00",
         "files": {"bam": [bam]},
@@ -129,6 +134,7 @@ def test_rna_fastq():
 
     # create the rna_expression object
     r1 = ARTIFACT_OBJ.copy()
+    r1["data_format"] = "FASTQ.GZ"
     record = {
         "library_yield_ng": 666,
         "dv200": 0.7,
@@ -162,6 +168,7 @@ def test_rna_bam():
 
     # create the rna_expression object
     bam = ARTIFACT_OBJ.copy()
+    bam["data_format"] = "BAM"
     record = {
         "cimac_id": "CTTTPPPSA.00",
         "library_yield_ng": 666,
@@ -184,7 +191,9 @@ def test_tcr_fastq():
 
     # create the tcr_seq object
     r1 = ARTIFACT_OBJ.copy()
+    r1["data_format"] = "FASTQ.GZ"
     sample_sheet = ARTIFACT_OBJ.copy()
+    sample_sheet["data_format"] = "CSV"
     record = {
         "cimac_id": "CTTTPPPSA.00",
         "files": {
@@ -230,9 +239,13 @@ def test_cytof_10021():
     validator = jsonschema.Draft7Validator(schema)
 
     fcs_1 = ARTIFACT_OBJ.copy()
+    fcs_1["data_format"] = "FCS"
     fcs_2 = ARTIFACT_OBJ.copy()
+    fcs_2["data_format"] = "FCS"
     fcs_3 = ARTIFACT_OBJ.copy()
+    fcs_3["data_format"] = "FCS"
     fcs_4 = ARTIFACT_OBJ.copy()
+    fcs_4["data_format"] = "FCS"
     record = {"processed_fcs": fcs_1, "intermediate_fcs": fcs_4}
     validator.validate(record)
 
@@ -267,16 +280,27 @@ def test_cytof_10021():
 
     # create the cytof object
     fcs_1 = ARTIFACT_OBJ.copy()
+    fcs_1["data_format"] = "FCS"
     fcs_2 = ARTIFACT_OBJ.copy()
+    fcs_2["data_format"] = "FCS"
     fcs_3 = ARTIFACT_OBJ.copy()
+    fcs_3["data_format"] = "FCS"
     assignment = ARTIFACT_OBJ.copy()
+    assignment["data_format"] = "CSV"
     compartment = ARTIFACT_OBJ.copy()
+    compartment["data_format"] = "CSV"
     profiling = ARTIFACT_OBJ.copy()
+    profiling["data_format"] = "CSV"
     cell_count_assignment = ARTIFACT_OBJ.copy()
+    cell_count_assignment["data_format"] = "CSV"
     cell_count_compartment = ARTIFACT_OBJ.copy()
+    cell_count_compartment["data_format"] = "CSV"
     cell_count_profiling = ARTIFACT_OBJ.copy()
+    cell_count_profiling["data_format"] = "CSV"
     report = ARTIFACT_OBJ.copy()
+    report["data_format"] = "ZIP"
     analysis = ARTIFACT_OBJ.copy()
+    analysis["data_format"] = "ZIP"
     record = {
         "cimac_id": "CTTTPPPSA.00",
         "input_files": {"processed_fcs": fcs_1},
@@ -309,9 +333,13 @@ def test_cytof_e4412():
     validator = jsonschema.Draft7Validator(schema)
 
     fcs_1 = ARTIFACT_OBJ.copy()
+    fcs_1["data_format"] = "FCS"
     fcs_2 = ARTIFACT_OBJ.copy()
+    fcs_2["data_format"] = "FCS"
     fcs_3 = ARTIFACT_OBJ.copy()
+    fcs_3["data_format"] = "FCS"
     fcs_4 = ARTIFACT_OBJ.copy()
+    fcs_4["data_format"] = "FCS"
     record = {"processed_fcs": fcs_1, "intermediate_fcs": fcs_4}
     validator.validate(record)
 
@@ -343,16 +371,27 @@ def test_cytof_e4412():
 
     # create the cytof object
     fcs_1 = ARTIFACT_OBJ.copy()
+    fcs_1["data_format"] = "FCS"
     fcs_2 = ARTIFACT_OBJ.copy()
+    fcs_2["data_format"] = "FCS"
     fcs_3 = ARTIFACT_OBJ.copy()
+    fcs_3["data_format"] = "FCS"
     assignment = ARTIFACT_OBJ.copy()
+    assignment["data_format"] = "CSV"
     compartment = ARTIFACT_OBJ.copy()
+    compartment["data_format"] = "CSV"
     profiling = ARTIFACT_OBJ.copy()
+    profiling["data_format"] = "CSV"
     cell_count_assignment = ARTIFACT_OBJ.copy()
+    cell_count_assignment["data_format"] = "CSV"
     cell_count_compartment = ARTIFACT_OBJ.copy()
+    cell_count_compartment["data_format"] = "CSV"
     cell_count_profiling = ARTIFACT_OBJ.copy()
+    cell_count_profiling["data_format"] = "CSV"
     report = ARTIFACT_OBJ.copy()
+    report["data_format"] = "ZIP"
     analysis = ARTIFACT_OBJ.copy()
+    analysis["data_format"] = "ZIP"
     participant = {
         "cimac_participant_id": "CTTTPPP",
         "control": {"input_files": {"processed_fcs": fcs_2},},
@@ -407,6 +446,7 @@ def test_ihc():
 
     # create the artifact object
     image_1 = ARTIFACT_OBJ.copy()
+    image_1["data_format"] = "IMAGE"
     image_1["height"] = 300
     image_1["width"] = 250
     image_1["channels"] = 3
@@ -435,10 +475,12 @@ def test_mif():
 
     # create the artifact object
     image = ARTIFACT_OBJ.copy()
+    image["data_format"] = "IMAGE"
     image["height"] = 300
     image["width"] = 250
     image["channels"] = 3
     text = ARTIFACT_OBJ.copy()
+    text["data_format"] = "TEXT"
     record = {
         "cimac_id": "CTTTPPPSA.00",
         "files": {
@@ -502,11 +544,14 @@ def test_micsss():
 
     # create the artifact object
     image = ARTIFACT_OBJ.copy()
+    image["data_format"] = "IMAGE"
     image["height"] = 300
     image["width"] = 250
     image["channels"] = 3
     text = ARTIFACT_OBJ.copy()
+    text["data_format"] = "TEXT"
     csv = ARTIFACT_OBJ.copy()
+    csv["data_format"] = "CSV"
     record = {
         "project_qupath_folder": "dummy",
         "micsss_exported_data_folder": "dummy_value",
@@ -546,9 +591,11 @@ def test_olink():
 
     # build up the batch object with one record
     npx = ARTIFACT_OBJ.copy()
+    npx["data_format"] = "NPX"
     npx["samples"] = ["CTTTPPPS1.00", "CTTTPPPS2.00", "CTTTPPPS3.00"]
     npx["number_of_samples"] = 3
     csv = ARTIFACT_OBJ.copy()
+    csv["data_format"] = "CSV"
     record = OLINK_RECORD.copy()
     record["files"]["assay_npx"] = npx
     record["files"]["assay_raw_ct"] = csv
@@ -582,6 +629,8 @@ def test_clinicaldata():
 
     # create clinical data that is valid
     tmp = ARTIFACT_OBJ.copy()
+    tmp["file_name"] = "dummy.xlsx"
+    tmp["data_format"] = "XLSX"
     tmp["participants"] = ["CTTTPPP", "CTTTPPQ", "CTTTPPD"]
     tmp["number_of_participants"] = 3
     clin_dat = {"records": [{"clinical_file": tmp, "comment": "dummyxyz"}]}
@@ -593,9 +642,12 @@ def test_clinicaldata():
     obj = {**ASSAY_CORE, **clin_dat}
     validator.validate(obj)
 
-    # try to validate this (expect failure on missing number_of_participants)
-    del tmp["number_of_participants"]
+    # try to validate this (expect failure on filetype)
+    tmp = ARTIFACT_OBJ.copy()
+    tmp["file_name"] = "dummy.xlsx"
+    tmp["participants"] = ["CTTTPPP", "CTTTPPQ", "CTTTPPD"]
+    tmp["number_of_participants"] = 3
     clin_dat = {"records": [{"clinical_file": tmp, "comment": "dummyxyz"}]}
     obj = {**ASSAY_CORE, **clin_dat}
-    with pytest.raises(jsonschema.ValidationError):
+    with pytest.raises(jsonschema.ValidationError, match="'XLSX' was expected"):
         validator.validate(clin_dat)


### PR DESCRIPTION
A non-breaking approach to #440 - this PR doesn't invalidate existing artifact metadata that includes `data_format` and `file_name`, but allows future artifact metadata to leave these fields empty.