### PR TITLE
CIDC-1124 update preamble reqs for mIF

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.29"
+__version__ = "0.25.30"

--- a/cidc_schemas/schemas/assays/components/image.json
+++ b/cidc_schemas/schemas/assays/components/image.json
@@ -9,7 +9,7 @@
     "slide_scanner_model": {
       "description": "Model version of the slide scanner instrument.",
       "type": "string",
-      "enum": ["Vectra 2.0", "Hamamatsu", "VectraPolaris/3.0.3"]
+      "enum": ["Vectra 2.0", "Hamamatsu", "VectraPolaris/3.0.3", "Not Provided"]
     },
     "image_analysis_software": {
       "description": "Source software for digital pathology and image analysis.",

--- a/cidc_schemas/schemas/assays/mif_assay.json
+++ b/cidc_schemas/schemas/assays/mif_assay.json
@@ -32,7 +32,8 @@
         "Panel 1: PD-L1, CD68, PD-1, CD8, CD3, pan-cytokeratin, DAPI",
         "Panel 2: FOXP3, Granzyme B, CD45RO, CD8, CD3, pan-cytokeratin, DAPI",
         "Panel 3: pan-cytokeratin, CD8, PD-1, PD-L1, DAPI",
-        "Panel 4: SOX10, CD8, PD-1, PD-L1, DAPI"
+        "Panel 4: SOX10, CD8, PD-1, PD-L1, DAPI",
+        "Not Provided"
       ]
     },
     "excluded_samples": {

--- a/cidc_schemas/schemas/templates/metadata/mif_template.json
+++ b/cidc_schemas/schemas/templates/metadata/mif_template.json
@@ -28,12 +28,14 @@
                     "image analysis software":
                     {
                         "merge_pointer": "0/image_analysis_software",
-                        "type_ref": "assays/mif_assay.json#properties/image_analysis_software"
+                        "type_ref": "assays/mif_assay.json#properties/image_analysis_software",
+                        "allow_empty": true
                     },
                     "image analysis software version":
                     {
                         "merge_pointer": "0/image_analysis_software_version",
-                        "type_ref": "assays/mif_assay.json#properties/image_analysis_software_version"
+                        "type_ref": "assays/mif_assay.json#properties/image_analysis_software_version",
+                        "allow_empty": true
                     },
                     "cell segmentation model":
                     {
@@ -56,7 +58,8 @@
                     "staining date":
                     {
                         "merge_pointer": "0/staining_date",
-                        "type_ref": "assays/components/imaging_data.json#properties/staining_date"
+                        "type_ref": "assays/components/imaging_data.json#properties/staining_date",
+                        "allow_empty": true
                     },
                     "imaging date":
                     {
@@ -67,7 +70,8 @@
                     "imaging status":
                     {
                         "merge_pointer": "0/imaging_status",
-                        "type_ref": "assays/components/imaging_data.json#properties/imaging_status"
+                        "type_ref": "assays/components/imaging_data.json#properties/imaging_status",
+                        "allow_empty": true
                     },
                     "panel":
                     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jsonpointer==2.0
 pandas==1.2.4
 jinja2==2.10.3
 cidc-ngs-pipeline-api==0.1.18
+markupsafe==2.0.1


### PR DESCRIPTION
## What

Update schema requirements for mIF preamble to allow for missing data

## Why

allows for the ingestion of 9204 mIF from CIDC-1124 with empty preamble fields

## How

Describe details of how you implemented the solution, outlining the major steps involved in adding this new feature or fixing this bug. Provide code-snippets if possible, showing example usage.

## Remarks

Add notes on possible known quirks/drawbacks of this solution.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
