### PR TITLE
Regex peg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.31` - 25 Mar 2022
+
+- `added` version peg for regex library to prevent errors in date format validation
+
+## Version `0.25.30` - 2 Mar 2022
+
+- `added` not provided option for mIF slide scanner model
+- `fixed` mIF template to allow empty on all nonrequired fields
+
 ## Version `0.25.29` - 27 Jan 2022
 
 - `added` backwards compatibility for 10021 WES analysis

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.30"
+__version__ = "0.25.31"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas==1.2.4
 jinja2==2.10.3
 cidc-ngs-pipeline-api==0.1.18
 markupsafe==2.0.1
+regex==2022.3.2


### PR DESCRIPTION
## What

Peg version for `regex` library to prevent errors in date format validation.

## Why

`regex==2022.3.15` throws `bad escape \d at position` when validating dates in manifest uploads

## How

Peg to last known working version.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
