### PR TITLE
CIDC-1339 add long_description for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ from setuptools import setup, find_packages
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
-with open("HISTORY.rst") as history_file:
-    history = history_file.read()
-
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
@@ -31,9 +28,8 @@ setup(
     python_requires=">=3.6",
     install_requires=requirements,
     license="MIT license",
-    # TODO: work this out - we can't mix content types (.md and .rst)
-    # in the long_description.
-    # long_description=readme + '\n\n' + history,
+    long_description=readme,
+    long_description_content_type="text/markdown",
     include_package_data=True,
     keywords="cidc_schemas",
     name="cidc_schemas",


### PR DESCRIPTION


PyPI deploy [is currently failing](https://github.com/CIMAC-CIDC/cidc-schemas/runs/6529886413?check_suite_focus=true#step:5:11) on `long_description` despite not providing one

## How

Per [python's documentation](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata) provide the contents of `README.md` as `long_description` to `setup`  with `long_description_content_type` as `text/markdown`.