### PR TITLE
CIDC-987 widely relax manifest requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.39` - 13 Jun 2022
+
+- `changed` shipping manifests to relax lots of previously required fields
+
 ## Version `0.25.38` - 8 Jun 2022
 
 - `added` support for microbiome DNA, microbiome, and microbiome analysis

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.38"
+__version__ = "0.25.39"

--- a/cidc_schemas/schemas/shipping_core.json
+++ b/cidc_schemas/schemas/shipping_core.json
@@ -5,6 +5,10 @@
   "type": "object",
   "description": "Core shipping details for a manifest.",
   "additionalProperties": false,
+  "required": [
+    "manifest_id",
+    "assay_type"
+  ],
   "properties": {
     "manifest_id": {
       "description": "Filename of the manifest used to ship this sample. Example: E4412_PBMC.",

--- a/cidc_schemas/schemas/templates/manifests/h_and_e_template.json
+++ b/cidc_schemas/schemas/templates/manifests/h_and_e_template.json
@@ -19,7 +19,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -27,43 +28,53 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
-                        "type_ref": "shipping_core.json#properties/date_shipped"
+                        "type_ref": "shipping_core.json#properties/date_shipped",
+                        "allow_empty": true
                     },
                     "date received": {
                         "merge_pointer": "/date_received",
-                        "type_ref": "shipping_core.json#properties/date_received"
+                        "type_ref": "shipping_core.json#properties/date_received",
+                        "allow_empty": true
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -113,11 +124,13 @@
                     "Specimen Info Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "/type_of_sample",
@@ -133,7 +146,8 @@
                         },
                         "core number": {
                             "merge_pointer": "/core_number",
-                            "type_ref": "sample.json#properties/core_number"
+                            "type_ref": "sample.json#properties/core_number",
+                            "allow_empty": true
                         },
                         "fixation/stabilization type": {
                             "merge_pointer": "/fixation_stabilization_type",
@@ -145,7 +159,8 @@
                         },
                         "processed sample quantity": {
                             "merge_pointer": "/processed_sample_quantity",
-                            "type_ref": "sample.json#properties/processed_sample_quantity"
+                            "type_ref": "sample.json#properties/processed_sample_quantity",
+                            "allow_empty": true
                         },
                         "tumor tissue (% total area)": {
                             "merge_pointer": "/tumor_tissue_total_area_percentage",
@@ -175,35 +190,43 @@
                         },
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material used units": {
                             "merge_pointer": "/material_used_units",
-                            "type_ref": "sample.json#properties/material_used_units"
+                            "type_ref": "sample.json#properties/material_used_units",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material remaining units": {
                             "merge_pointer": "/material_remaining_units",
-                            "type_ref": "sample.json#properties/material_remaining_units"
+                            "type_ref": "sample.json#properties/material_remaining_units",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",

--- a/cidc_schemas/schemas/templates/manifests/normal_blood_dna_template.json
+++ b/cidc_schemas/schemas/templates/manifests/normal_blood_dna_template.json
@@ -18,7 +18,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -26,43 +27,53 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
-                        "type_ref": "shipping_core.json#properties/date_shipped"
+                        "type_ref": "shipping_core.json#properties/date_shipped",
+                        "allow_empty": true
                     },
                     "date received": {
                         "merge_pointer": "/date_received",
-                        "type_ref": "shipping_core.json#properties/date_received"
+                        "type_ref": "shipping_core.json#properties/date_received",
+                        "allow_empty": true
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -111,11 +122,13 @@
                     "Specimen Info Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "/type_of_sample",
@@ -136,15 +149,18 @@
                         },
                         "processed sample volume": {
                             "merge_pointer": "/processed_sample_volume",
-                            "type_ref": "sample.json#properties/processed_sample_volume"
+                            "type_ref": "sample.json#properties/processed_sample_volume",
+                            "allow_empty": true
                         },
                         "processed sample volume units": {
                             "merge_pointer": "/processed_sample_volume_units",
-                            "type_ref": "sample.json#properties/processed_sample_volume_units"
+                            "type_ref": "sample.json#properties/processed_sample_volume_units",
+                            "allow_empty": true
                         },
                         "processed sample quantity": {
                             "merge_pointer": "/processed_sample_quantity",
-                            "type_ref": "sample.json#properties/processed_sample_quantity"
+                            "type_ref": "sample.json#properties/processed_sample_quantity",
+                            "allow_empty": true
                         },
                         "processed sample derivative": {
                             "merge_pointer": "/processed_sample_derivative",
@@ -152,7 +168,8 @@
                         },
                         "sample derivative volume": {
                             "merge_pointer": "/sample_derivative_volume",
-                            "type_ref": "sample.json#properties/sample_derivative_volume"
+                            "type_ref": "sample.json#properties/sample_derivative_volume",
+                            "allow_empty": true
                         },
                         "sample derivative volume units": {
                             "merge_pointer": "/sample_derivative_volume_units",
@@ -161,11 +178,13 @@
                         },
                         "sample derivative concentration": {
                             "merge_pointer": "/sample_derivative_concentration",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration",
+                            "allow_empty": true
                         },
                         "sample derivative concentration units": {
                             "merge_pointer": "/sample_derivative_concentration_units",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration_units"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration_units",
+                            "allow_empty": true
                         }
                     },
                     "DNA quality": {
@@ -185,35 +204,43 @@
                     "Filled by CIMAC Lab": {
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material used units": {
                             "merge_pointer": "/material_used_units",
-                            "type_ref": "sample.json#properties/material_used_units"
+                            "type_ref": "sample.json#properties/material_used_units",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material remaining units": {
                             "merge_pointer": "/material_remaining_units",
-                            "type_ref": "sample.json#properties/material_remaining_units"
+                            "type_ref": "sample.json#properties/material_remaining_units",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",

--- a/cidc_schemas/schemas/templates/manifests/normal_tissue_dna_template.json
+++ b/cidc_schemas/schemas/templates/manifests/normal_tissue_dna_template.json
@@ -19,7 +19,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -27,43 +28,53 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
-                        "type_ref": "shipping_core.json#properties/date_shipped"
+                        "type_ref": "shipping_core.json#properties/date_shipped",
+                        "allow_empty": true
                     },
                     "date received": {
                         "merge_pointer": "/date_received",
-                        "type_ref": "shipping_core.json#properties/date_received"
+                        "type_ref": "shipping_core.json#properties/date_received",
+                        "allow_empty": true
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -114,11 +125,13 @@
                     "Specimen Info Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "/type_of_sample",
@@ -130,7 +143,8 @@
                         },
                         "core number": {
                             "merge_pointer": "/core_number",
-                            "type_ref": "sample.json#properties/core_number"
+                            "type_ref": "sample.json#properties/core_number",
+                            "allow_empty": true
                         },
                         "fixation/stabilization type": {
                             "merge_pointer": "/fixation_stabilization_type",
@@ -142,7 +156,8 @@
                         },
                         "processed sample quantity": {
                             "merge_pointer": "/processed_sample_quantity",
-                            "type_ref": "sample.json#properties/processed_sample_quantity"
+                            "type_ref": "sample.json#properties/processed_sample_quantity",
+                            "allow_empty": true
                         },
                         "processed sample derivative": {
                             "merge_pointer": "/processed_sample_derivative",
@@ -150,19 +165,23 @@
                         },
                         "sample derivative volume": {
                             "merge_pointer": "/sample_derivative_volume",
-                            "type_ref": "sample.json#properties/sample_derivative_volume"
+                            "type_ref": "sample.json#properties/sample_derivative_volume",
+                            "allow_empty": true
                         },
                         "sample derivative volume units": {
                             "merge_pointer": "/sample_derivative_volume_units",
-                            "type_ref": "sample.json#properties/sample_derivative_volume_units"
+                            "type_ref": "sample.json#properties/sample_derivative_volume_units",
+                            "allow_empty": true
                         },
                         "sample derivative concentration": {
                             "merge_pointer": "/sample_derivative_concentration",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration",
+                            "allow_empty": true
                         },
                         "sample derivative concentration units": {
                             "merge_pointer": "/sample_derivative_concentration_units",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration_units"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration_units",
+                            "allow_empty": true
                         }
                     },
                     "DNA quality": {
@@ -182,35 +201,43 @@
                     "Filled by CIMAC Lab": {
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material used units": {
                             "merge_pointer": "/material_used_units",
-                            "type_ref": "sample.json#properties/material_used_units"
+                            "type_ref": "sample.json#properties/material_used_units",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material remaining units": {
                             "merge_pointer": "/material_remaining_units",
-                            "type_ref": "sample.json#properties/material_remaining_units"
+                            "type_ref": "sample.json#properties/material_remaining_units",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",

--- a/cidc_schemas/schemas/templates/manifests/pbmc_template.json
+++ b/cidc_schemas/schemas/templates/manifests/pbmc_template.json
@@ -19,7 +19,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -27,43 +28,53 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
-                        "type_ref": "shipping_core.json#properties/date_shipped"
+                        "type_ref": "shipping_core.json#properties/date_shipped",
+                        "allow_empty": true
                     },
                     "date received": {
                         "merge_pointer": "/date_received",
-                        "type_ref": "shipping_core.json#properties/date_received"
+                        "type_ref": "shipping_core.json#properties/date_received",
+                        "allow_empty": true
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -196,11 +207,13 @@
                     "Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "0/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "0/type_of_sample",
@@ -220,19 +233,23 @@
                         },
                         "processed sample volume": {
                             "merge_pointer": "/processed_sample_volume",
-                            "type_ref": "sample.json#properties/processed_sample_volume"
+                            "type_ref": "sample.json#properties/processed_sample_volume",
+                            "allow_empty": true
                         },
                         "processed sample volume units": {
                             "merge_pointer": "/processed_sample_volume_units",
-                            "type_ref": "sample.json#properties/processed_sample_volume_units"
+                            "type_ref": "sample.json#properties/processed_sample_volume_units",
+                            "allow_empty": true
                         },
                         "processed sample concentration": {
                             "merge_pointer": "/processed_sample_concentration",
-                            "type_ref": "sample.json#properties/processed_sample_concentration"
+                            "type_ref": "sample.json#properties/processed_sample_concentration",
+                            "allow_empty": true
                         },
                         "processed sample concentration units": {
                             "merge_pointer": "/processed_sample_concentration_units",
-                            "type_ref": "sample.json#properties/processed_sample_concentration_units"
+                            "type_ref": "sample.json#properties/processed_sample_concentration_units",
+                            "allow_empty": true
                         },
                         "processed sample derivative": {
                             "merge_pointer": "/processed_sample_derivative",
@@ -262,39 +279,48 @@
                     "Filled by CIMAC Lab": {
                         "pbmc viability": {
                             "merge_pointer": "/pbmc_viability",
-                            "type_ref": "sample.json#properties/pbmc_viability"
+                            "type_ref": "sample.json#properties/pbmc_viability",
+                            "allow_empty": true
                         },
                         "pbmc recovery": {
                             "merge_pointer": "/pbmc_recovery",
-                            "type_ref": "sample.json#properties/pbmc_recovery"
+                            "type_ref": "sample.json#properties/pbmc_recovery",
+                            "allow_empty": true
                         },
                         "pbmc resting period used": {
                             "merge_pointer": "/pbmc_resting_period_used",
-                            "type_ref": "sample.json#properties/pbmc_resting_period_used"
+                            "type_ref": "sample.json#properties/pbmc_resting_period_used",
+                            "allow_empty": true
                         },
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",

--- a/cidc_schemas/schemas/templates/manifests/plasma_template.json
+++ b/cidc_schemas/schemas/templates/manifests/plasma_template.json
@@ -19,7 +19,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -27,23 +28,28 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
@@ -57,15 +63,18 @@
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -198,11 +207,13 @@
                     "Specimen Info Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "/type_of_sample",
@@ -222,45 +233,55 @@
                         },
                         "processed sample volume": {
                             "merge_pointer": "/processed_sample_volume",
-                            "type_ref": "sample.json#properties/processed_sample_volume"
+                            "type_ref": "sample.json#properties/processed_sample_volume",
+                            "allow_empty": true
                         },
                         "processed sample volume units": {
                             "merge_pointer": "/processed_sample_volume_units",
-                            "type_ref": "sample.json#properties/processed_sample_volume_units"
+                            "type_ref": "sample.json#properties/processed_sample_volume_units",
+                            "allow_empty": true
                         }
                     },
                     "Filled by CIMAC Lab": {
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material used units": {
                             "merge_pointer": "/material_used_units",
-                            "type_ref": "sample.json#properties/material_used_units"
+                            "type_ref": "sample.json#properties/material_used_units",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material remaining units": {
                             "merge_pointer": "/material_remaining_units",
-                            "type_ref": "sample.json#properties/material_remaining_units"
+                            "type_ref": "sample.json#properties/material_remaining_units",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",

--- a/cidc_schemas/schemas/templates/manifests/tissue_slide_template.json
+++ b/cidc_schemas/schemas/templates/manifests/tissue_slide_template.json
@@ -19,7 +19,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -27,43 +28,53 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
-                        "type_ref": "shipping_core.json#properties/date_shipped"
+                        "type_ref": "shipping_core.json#properties/date_shipped",
+                        "allow_empty": true
                     },
                     "date received": {
                         "merge_pointer": "/date_received",
-                        "type_ref": "shipping_core.json#properties/date_received"
+                        "type_ref": "shipping_core.json#properties/date_received",
+                        "allow_empty": true
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -114,11 +125,13 @@
                     "Specimen Info Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "/type_of_sample",
@@ -134,7 +147,8 @@
                         },
                         "core number": {
                             "merge_pointer": "/core_number",
-                            "type_ref": "sample.json#properties/core_number"
+                            "type_ref": "sample.json#properties/core_number",
+                            "allow_empty": true
                         },
                         "fixation/stabilization type": {
                             "merge_pointer": "/fixation_stabilization_type",
@@ -146,41 +160,50 @@
                         },
                         "processed sample quantity": {
                             "merge_pointer": "/processed_sample_quantity",
-                            "type_ref": "sample.json#properties/processed_sample_quantity"
+                            "type_ref": "sample.json#properties/processed_sample_quantity",
+                            "allow_empty": true
                         }
                     },
                     "Filled by CIMAC Lab": {
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material used units": {
                             "merge_pointer": "/material_used_units",
-                            "type_ref": "sample.json#properties/material_used_units"
+                            "type_ref": "sample.json#properties/material_used_units",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material remaining units": {
                             "merge_pointer": "/material_remaining_units",
-                            "type_ref": "sample.json#properties/material_remaining_units"
+                            "type_ref": "sample.json#properties/material_remaining_units",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",

--- a/cidc_schemas/schemas/templates/manifests/tumor_tissue_dna_template.json
+++ b/cidc_schemas/schemas/templates/manifests/tumor_tissue_dna_template.json
@@ -19,7 +19,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -27,43 +28,53 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
-                        "type_ref": "shipping_core.json#properties/date_shipped"
+                        "type_ref": "shipping_core.json#properties/date_shipped",
+                        "allow_empty": true
                     },
                     "date received": {
                         "merge_pointer": "/date_received",
-                        "type_ref": "shipping_core.json#properties/date_received"
+                        "type_ref": "shipping_core.json#properties/date_received",
+                        "allow_empty": true
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -114,11 +125,13 @@
                     "Specimen Info Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "/type_of_sample",
@@ -134,7 +147,8 @@
                         },
                         "core number": {
                             "merge_pointer": "/core_number",
-                            "type_ref": "sample.json#properties/core_number"
+                            "type_ref": "sample.json#properties/core_number",
+                            "allow_empty": true
                         },
                         "fixation/stabilization type": {
                             "merge_pointer": "/fixation_stabilization_type",
@@ -146,27 +160,33 @@
                         },
                         "processed sample quantity": {
                             "merge_pointer": "/processed_sample_quantity",
-                            "type_ref": "sample.json#properties/processed_sample_quantity"
+                            "type_ref": "sample.json#properties/processed_sample_quantity",
+                            "allow_empty": true
                         },
                         "processed sample derivative": {
                             "merge_pointer": "/processed_sample_derivative",
-                            "type_ref": "sample.json#properties/processed_sample_derivative"
+                            "type_ref": "sample.json#properties/processed_sample_derivative",
+                            "allow_empty": true
                         },
                         "sample derivative volume": {
                             "merge_pointer": "/sample_derivative_volume",
-                            "type_ref": "sample.json#properties/sample_derivative_volume"
+                            "type_ref": "sample.json#properties/sample_derivative_volume",
+                            "allow_empty": true
                         },
                         "sample derivative volume units": {
                             "merge_pointer": "/sample_derivative_volume_units",
-                            "type_ref": "sample.json#properties/sample_derivative_volume_units"
+                            "type_ref": "sample.json#properties/sample_derivative_volume_units",
+                            "allow_empty": true
                         },
                         "sample derivative concentration": {
                             "merge_pointer": "/sample_derivative_concentration",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration",
+                            "allow_empty": true
                         },
                         "sample derivative concentration units": {
                             "merge_pointer": "/sample_derivative_concentration_units",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration_units"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration_units",
+                            "allow_empty": true
                         }
                     },
                     "DNA quality": {
@@ -186,35 +206,43 @@
                     "Filled by CIMAC Lab": {
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material used units": {
                             "merge_pointer": "/material_used_units",
-                            "type_ref": "sample.json#properties/material_used_units"
+                            "type_ref": "sample.json#properties/material_used_units",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material remaining units": {
                             "merge_pointer": "/material_remaining_units",
-                            "type_ref": "sample.json#properties/material_remaining_units"
+                            "type_ref": "sample.json#properties/material_remaining_units",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",

--- a/cidc_schemas/schemas/templates/manifests/tumor_tissue_rna_template.json
+++ b/cidc_schemas/schemas/templates/manifests/tumor_tissue_rna_template.json
@@ -19,7 +19,8 @@
                     },
                     "assay priority": {
                         "merge_pointer": "/assay_priority",
-                        "type_ref": "shipping_core.json#properties/assay_priority"
+                        "type_ref": "shipping_core.json#properties/assay_priority",
+                        "allow_empty": true
                     },
                     "assay type": {
                         "merge_pointer": "/assay_type",
@@ -27,43 +28,53 @@
                     },
                     "receiving party": {
                         "merge_pointer": "/receiving_party",
-                        "type_ref": "shipping_core.json#properties/receiving_party"
+                        "type_ref": "shipping_core.json#properties/receiving_party",
+                        "allow_empty": true
                     },
                     "courier": {
                         "merge_pointer": "/courier",
-                        "type_ref": "shipping_core.json#properties/courier"
+                        "type_ref": "shipping_core.json#properties/courier",
+                        "allow_empty": true
                     },
                     "tracking number": {
                         "merge_pointer": "/tracking_number",
-                        "type_ref": "shipping_core.json#properties/tracking_number"
+                        "type_ref": "shipping_core.json#properties/tracking_number",
+                        "allow_empty": true
                     },
                     "account number": {
                         "merge_pointer": "/account_number",
-                        "type_ref": "shipping_core.json#properties/account_number"
+                        "type_ref": "shipping_core.json#properties/account_number",
+                        "allow_empty": true
                     },
                     "shipping condition": {
                         "merge_pointer": "/shipping_condition",
-                        "type_ref": "shipping_core.json#properties/shipping_condition"
+                        "type_ref": "shipping_core.json#properties/shipping_condition",
+                        "allow_empty": true
                     },
                     "date shipped": {
                         "merge_pointer": "/date_shipped",
-                        "type_ref": "shipping_core.json#properties/date_shipped"
+                        "type_ref": "shipping_core.json#properties/date_shipped",
+                        "allow_empty": true
                     },
                     "date received": {
                         "merge_pointer": "/date_received",
-                        "type_ref": "shipping_core.json#properties/date_received"
+                        "type_ref": "shipping_core.json#properties/date_received",
+                        "allow_empty": true
                     },
                     "quality of shipment": {
                         "merge_pointer": "/quality_of_shipment",
-                        "type_ref": "shipping_core.json#properties/quality_of_shipment"
+                        "type_ref": "shipping_core.json#properties/quality_of_shipment",
+                        "allow_empty": true
                     },
                     "ship from": {
                         "merge_pointer": "/ship_from",
-                        "type_ref": "shipping_core.json#properties/ship_from"
+                        "type_ref": "shipping_core.json#properties/ship_from",
+                        "allow_empty": true
                     },
                     "ship to": {
                         "merge_pointer": "/ship_to",
-                        "type_ref": "shipping_core.json#properties/ship_to"
+                        "type_ref": "shipping_core.json#properties/ship_to",
+                        "allow_empty": true
                     }
                 }
             },
@@ -114,11 +125,13 @@
                     "Specimen Info Filled by Biorepository": {
                         "box number": {
                             "merge_pointer": "/box_number",
-                            "type_ref": "sample.json#properties/box_number"
+                            "type_ref": "sample.json#properties/box_number",
+                            "allow_empty": true
                         },
                         "sample location": {
                             "merge_pointer": "/sample_location",
-                            "type_ref": "sample.json#properties/sample_location"
+                            "type_ref": "sample.json#properties/sample_location",
+                            "allow_empty": true
                         },
                         "type of sample": {
                             "merge_pointer": "/type_of_sample",
@@ -134,7 +147,8 @@
                         },
                         "core number": {
                             "merge_pointer": "/core_number",
-                            "type_ref": "sample.json#properties/core_number"
+                            "type_ref": "sample.json#properties/core_number",
+                            "allow_empty": true
                         },
                         "fixation/stabilization type": {
                             "merge_pointer": "/fixation_stabilization_type",
@@ -146,7 +160,8 @@
                         },
                         "processed sample quantity": {
                             "merge_pointer": "/processed_sample_quantity",
-                            "type_ref": "sample.json#properties/processed_sample_quantity"
+                            "type_ref": "sample.json#properties/processed_sample_quantity",
+                            "allow_empty": true
                         },
                         "processed sample derivative": {
                             "merge_pointer": "/processed_sample_derivative",
@@ -154,53 +169,65 @@
                         },
                         "sample derivative volume": {
                             "merge_pointer": "/sample_derivative_volume",
-                            "type_ref": "sample.json#properties/sample_derivative_volume"
+                            "type_ref": "sample.json#properties/sample_derivative_volume",
+                            "allow_empty": true
                         },
                         "sample derivative volume units": {
                             "merge_pointer": "/sample_derivative_volume_units",
-                            "type_ref": "sample.json#properties/sample_derivative_volume_units"
+                            "type_ref": "sample.json#properties/sample_derivative_volume_units",
+                            "allow_empty": true
                         },
                         "sample derivative concentration": {
                             "merge_pointer": "/sample_derivative_concentration",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration",
+                            "allow_empty": true
                         },
                         "sample derivative concentration units": {
                             "merge_pointer": "/sample_derivative_concentration_units",
-                            "type_ref": "sample.json#properties/sample_derivative_concentration_units"
+                            "type_ref": "sample.json#properties/sample_derivative_concentration_units",
+                            "allow_empty": true
                         }
                     },
                     "Filled by CIMAC Lab": {
                         "material used": {
                             "merge_pointer": "/material_used",
-                            "type_ref": "sample.json#properties/material_used"
+                            "type_ref": "sample.json#properties/material_used",
+                            "allow_empty": true
                         },
                         "material used units": {
                             "merge_pointer": "/material_used_units",
-                            "type_ref": "sample.json#properties/material_used_units"
+                            "type_ref": "sample.json#properties/material_used_units",
+                            "allow_empty": true
                         },
                         "material remaining": {
                             "merge_pointer": "/material_remaining",
-                            "type_ref": "sample.json#properties/material_remaining"
+                            "type_ref": "sample.json#properties/material_remaining",
+                            "allow_empty": true
                         },
                         "material remaining units": {
                             "merge_pointer": "/material_remaining_units",
-                            "type_ref": "sample.json#properties/material_remaining_units"
+                            "type_ref": "sample.json#properties/material_remaining_units",
+                            "allow_empty": true
                         },
                         "material storage condition": {
                             "merge_pointer": "/material_storage_condition",
-                            "type_ref": "sample.json#properties/material_storage_condition"
+                            "type_ref": "sample.json#properties/material_storage_condition",
+                            "allow_empty": true
                         },
                         "quality of sample": {
                             "merge_pointer": "/quality_of_sample",
-                            "type_ref": "sample.json#properties/quality_of_sample"
+                            "type_ref": "sample.json#properties/quality_of_sample",
+                            "allow_empty": true
                         },
                         "sample replacement": {
                             "merge_pointer": "/sample_replacement",
-                            "type_ref": "sample.json#properties/sample_replacement"
+                            "type_ref": "sample.json#properties/sample_replacement",
+                            "allow_empty": true
                         },
                         "residual sample use": {
                             "merge_pointer": "/residual_sample_use",
-                            "type_ref": "sample.json#properties/residual_sample_use"
+                            "type_ref": "sample.json#properties/residual_sample_use",
+                            "allow_empty": true
                         },
                         "comments": {
                             "merge_pointer": "/comments",


### PR DESCRIPTION
## What

Allow empty values in a number of shipping manifest fields, both on the shipment itself as well as samples.

## Why

- Address [CIDC-987](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-987) Allow `Not Reported` in numeric fields - namely shipment `Core Number`
- Often get manifests missing lots of data that are never filled in later.

## How

- Add `"allow_empty": true` to many values across shipping manifests
- Add explicit requirements for `batch_id` and `assay_type` in `shipping_core.json` to prevent accidental future extension

## Remarks

Doesn't directly follow ticket, but is more expansive.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
