### PR TITLE
CIDC-987 relax new shipping req

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.40` - 13 Jun 2022
+
+- `removed` requirement in shipping_core for assay_type
+
 ## Version `0.25.39` - 13 Jun 2022
 
 - `changed` shipping manifests to relax lots of previously required fields
+- `added` requirement in shipping_core for manifest_id and assay_type
 
 ## Version `0.25.38` - 8 Jun 2022
 

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.39"
+__version__ = "0.25.40"

--- a/cidc_schemas/schemas/shipping_core.json
+++ b/cidc_schemas/schemas/shipping_core.json
@@ -6,8 +6,7 @@
   "description": "Core shipping details for a manifest.",
   "additionalProperties": false,
   "required": [
-    "manifest_id",
-    "assay_type"
+    "manifest_id"
   ],
   "properties": {
     "manifest_id": {


### PR DESCRIPTION
## What

Remove (new) requirement for shipments to be marked for a particular assay type

## Why

- Discovered in API testing
- CSMS does not guarantee samples/shipments are marked for a particular assay type.
- Added based on schematic consistency in passing during relaxation of shipping manifest template requirements in
  - https://github.com/CIMAC-CIDC/cidc-schemas/pull/530

## How

Removed `assay_type` from `required` in `shipping_core.json`

## Remarks

Obviously not favorable, but necessary given the requirement for compatibility with CSMS.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
