### PR TITLE
CIDC-1386 schemas updates for WES v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.42` - 8 Jul 2022
+
+- `added` wes_analysis_old and wes_tumor_only_analysis_old
+- `added` compatibility with WES analysis v3 as in Len's PR (maintaining existing)
+- `changed` conversions in generating analysis template automatically
+
 ## Version `0.25.41` - 17 Jun 2022
 
 - `added` 'Agilent SS Human All Exon V4' bait set option for wes assay

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.41"
+__version__ = "0.25.42"

--- a/cidc_schemas/migrations.py
+++ b/cidc_schemas/migrations.py
@@ -42,6 +42,58 @@ class migration:
         raise NotImplementedError
 
 
+class v0_25_41_to_v0_25_042(migration):
+    """
+    Move existing WES analysis files to wes_analysis_old and
+    WES Tumor-only analysis files to wes_tumor_only_analysis_old
+
+    To accommodate the introduction of WES analysis pipeline v3
+    """
+
+    @classmethod
+    def upgrade(cls, metadata: dict, *args, **kwargs) -> MigrationResult:
+        if "analyses" not in metadata or all(
+            [
+                a not in metadata["analyses"]
+                for a in ["wes_analysis", "wes_tumor_only_analysis"]
+            ]
+        ):
+            return MigrationResult(metadata, {})
+
+        if "wes_analysis" in metadata["analyses"]:
+            metadata["analyses"]["wes_analysis_old"] = metadata["analyses"].pop(
+                "wes_analysis"
+            )
+        if "wes_tumor_only_analysis" in metadata["analyses"]:
+            metadata["analyses"]["wes_tumor_only_analysis_old"] = metadata[
+                "analyses"
+            ].pop("wes_tumor_only_analysis")
+
+        return MigrationResult(metadata, {})
+
+    @classmethod
+    def downgrade(cls, metadata: dict, *args, **kwargs) -> MigrationResult:
+
+        if "analyses" not in metadata or all(
+            [
+                a not in metadata["analyses"]
+                for a in ["wes_analysis_old", "wes_tumor_only_analysis_old"]
+            ]
+        ):
+            return MigrationResult(metadata, {})
+
+        if "wes_analysis_old" in metadata["analyses"]:
+            metadata["analyses"]["wes_analysis"] = metadata["analyses"].pop(
+                "wes_analysis_old"
+            )
+        if "wes_tumor_only_analysis_old" in metadata["analyses"]:
+            metadata["analyses"]["wes_tumor_only_analysis"] = metadata["analyses"].pop(
+                "wes_tumor_only_analysis_old"
+            )
+
+        return MigrationResult(metadata, {})
+
+
 class v0_23_18_to_v0_24_0(migration):
     """
     Restructure the Olink data model, introducing the concept of batches representing
@@ -165,7 +217,7 @@ class v0_21_1_to_v0_22_0(migration):
 
     @classmethod
     def downgrade(cls, metadata: dict, *args, **kwargs):
-        MigrationResult(metadata, {})
+        return MigrationResult(metadata, {})
 
 
 class v0_15_2_to_v0_15_3(migration):

--- a/cidc_schemas/migrations.py
+++ b/cidc_schemas/migrations.py
@@ -42,7 +42,7 @@ class migration:
         raise NotImplementedError
 
 
-class v0_25_41_to_v0_25_042(migration):
+class v0_25_41_to_v0_25_42(migration):
     """
     Move existing WES analysis files to wes_analysis_old and
     WES Tumor-only analysis files to wes_tumor_only_analysis_old

--- a/cidc_schemas/schemas/artifacts/artifact_cncf.json
+++ b/cidc_schemas/schemas/artifacts/artifact_cncf.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "metaschema/strict_meta_schema.json#",
+  "$id": "cncf_artifact",
+  "title": "CNCF Artifact",
+  "type": "object",
+  "description": "Information about a CNCF file.",
+  "additionalProperties": false,
+  "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "CNCF"
+    },
+    "upload_placeholder": {
+      "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
+    },
+    "artifact_creator": {
+      "$ref": "artifacts/artifact_core.json#properties/artifact_creator"
+    },
+    "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
+    "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
+    "object_url": {
+      "$ref": "artifacts/artifact_core.json#properties/object_url"
+    },
+    "uploaded_timestamp": {
+      "$ref": "artifacts/artifact_core.json#properties/uploaded_timestamp"
+    },
+    "file_size_bytes": {
+      "$ref": "artifacts/artifact_core.json#properties/file_size_bytes"
+    },
+    "md5_hash": { "$ref": "artifacts/artifact_core.json#properties/md5_hash" },
+    "crc32c_hash": {
+      "$ref": "artifacts/artifact_core.json#properties/crc32c_hash"
+    },
+    "visible": { "$ref": "artifacts/artifact_core.json#properties/visible" },
+    "artifact_category": {
+      "$ref": "artifacts/artifact_core.json#properties/artifact_category"
+    },
+    "facet_group": {
+      "$ref": "artifacts/artifact_core.json#properties/facet_group"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "artifacts/artifact_core.json"
+    }
+  ],
+  "mergeStrategy": "objectMerge"
+}

--- a/cidc_schemas/schemas/artifacts/artifact_cns.json
+++ b/cidc_schemas/schemas/artifacts/artifact_cns.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "metaschema/strict_meta_schema.json#",
+  "$id": "cns_artifact",
+  "title": "CNS Artifact",
+  "type": "object",
+  "description": "Information about a CNS file.",
+  "additionalProperties": false,
+  "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "CNS"
+    },
+    "upload_placeholder": {
+      "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
+    },
+    "artifact_creator": {
+      "$ref": "artifacts/artifact_core.json#properties/artifact_creator"
+    },
+    "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
+    "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
+    "object_url": {
+      "$ref": "artifacts/artifact_core.json#properties/object_url"
+    },
+    "uploaded_timestamp": {
+      "$ref": "artifacts/artifact_core.json#properties/uploaded_timestamp"
+    },
+    "file_size_bytes": {
+      "$ref": "artifacts/artifact_core.json#properties/file_size_bytes"
+    },
+    "md5_hash": { "$ref": "artifacts/artifact_core.json#properties/md5_hash" },
+    "crc32c_hash": {
+      "$ref": "artifacts/artifact_core.json#properties/crc32c_hash"
+    },
+    "visible": { "$ref": "artifacts/artifact_core.json#properties/visible" },
+    "artifact_category": {
+      "$ref": "artifacts/artifact_core.json#properties/artifact_category"
+    },
+    "facet_group": {
+      "$ref": "artifacts/artifact_core.json#properties/facet_group"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "artifacts/artifact_core.json"
+    }
+  ],
+  "mergeStrategy": "objectMerge"
+}

--- a/cidc_schemas/schemas/artifacts/artifact_png.json
+++ b/cidc_schemas/schemas/artifacts/artifact_png.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "metaschema/strict_meta_schema.json#",
+  "$id": "png_artifact",
+  "title": "PNG Artifact",
+  "type": "object",
+  "description": "Information about a PNG file.",
+  "additionalProperties": false,
+  "properties": {
+    "data_format": {
+      "description": "Data format.",
+      "const": "PNG"
+    },
+    "upload_placeholder": {
+      "$ref": "artifacts/artifact_core.json#properties/upload_placeholder"
+    },
+    "artifact_creator": {
+      "$ref": "artifacts/artifact_core.json#properties/artifact_creator"
+    },
+    "uploader": { "$ref": "artifacts/artifact_core.json#properties/uploader" },
+    "uuid": { "$ref": "artifacts/artifact_core.json#properties/uuid" },
+    "file_name": {
+      "$ref": "artifacts/artifact_core.json#properties/file_name"
+    },
+    "object_url": {
+      "$ref": "artifacts/artifact_core.json#properties/object_url"
+    },
+    "uploaded_timestamp": {
+      "$ref": "artifacts/artifact_core.json#properties/uploaded_timestamp"
+    },
+    "file_size_bytes": {
+      "$ref": "artifacts/artifact_core.json#properties/file_size_bytes"
+    },
+    "md5_hash": { "$ref": "artifacts/artifact_core.json#properties/md5_hash" },
+    "crc32c_hash": {
+      "$ref": "artifacts/artifact_core.json#properties/crc32c_hash"
+    },
+    "visible": { "$ref": "artifacts/artifact_core.json#properties/visible" },
+    "artifact_category": {
+      "$ref": "artifacts/artifact_core.json#properties/artifact_category"
+    },
+    "facet_group": {
+      "$ref": "artifacts/artifact_core.json#properties/facet_group"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "artifacts/artifact_core.json"
+    }
+  ],
+  "mergeStrategy": "objectMerge"
+}

--- a/cidc_schemas/schemas/assays/components/available_ngs_analyses.json
+++ b/cidc_schemas/schemas/assays/components/available_ngs_analyses.json
@@ -13,6 +13,12 @@
     "wes_tumor_only_analysis": {
       "$ref": "assays/wes_tumor_only_analysis.json"
     },
+    "wes_analysis_old": {
+      "$ref": "assays/wes_analysis.json"
+    },
+    "wes_tumor_only_analysis_old": {
+      "$ref": "assays/wes_tumor_only_analysis.json"
+    },
     "rna_analysis": {
       "$ref": "assays/components/ngs/rna/rna_analysis.json"
     },

--- a/cidc_schemas/schemas/assays/wes_analysis.json
+++ b/cidc_schemas/schemas/assays/wes_analysis.json
@@ -58,6 +58,9 @@
         "rna": {
           "$ref": "assays/wes_core.json#definitions/rna"
         },
+        "tcell": {
+          "$ref": "assays/wes_core.json#definitions/tcell"
+        },
         "error": {
           "$ref": "assays/wes_core.json#properties/error"
         },

--- a/cidc_schemas/schemas/assays/wes_assay.json
+++ b/cidc_schemas/schemas/assays/wes_assay.json
@@ -46,7 +46,8 @@
           "alignment": {"$ref": "assays/wes_core.json#definitions/alignment"},
           "germline": {"$ref": "assays/wes_core.json#definitions/germline"},
           "optitype": {"$ref": "assays/wes_core.json#definitions/optitype"},
-          "metrics": {"$ref": "assays/wes_core.json#definitions/coverage_metrics"}
+          "metrics": {"$ref": "assays/wes_core.json#definitions/coverage_metrics"},
+          "hla": {"$ref": "assays/wes_core.json#definitions/hla"}
       }
     }
   },

--- a/cidc_schemas/schemas/assays/wes_core.json
+++ b/cidc_schemas/schemas/assays/wes_core.json
@@ -37,21 +37,25 @@
 	      "$ref": "artifacts/artifact_bam_bai.json"
 	    }
 	  },
+	  "required": [
+		  "align_sorted_dedup",
+		  "align_sorted_dedup_index"
+	  ],
 	  "oneOf": [
 		{
 			"required": [
-				"align_sorted_dedup",
-				"align_sorted_dedup_index",
 				"align_recalibrated",
 				"align_recalibrated_index"
 			],
 			"$comment": "WES v3 per ngs-api PR #55"
 		},
 		{
-			"required": [
-				"align_sorted_dedup",
-				"align_sorted_dedup_index"
-			],
+			"not": {
+				"required": [
+					"align_recalibrated",
+					"align_recalibrated_index"
+				]
+			},
 			"$comment": "maintained for backwards compatibility before v3"
 		}
 		],
@@ -171,7 +175,7 @@
 					"copynumber_consensus_gain",
 					"copynumber_consensus_loss",
 					"copynumber_facets",
-					"copynumber_factes_gainloss"
+					"copynumber_facets_gainloss"
 				],
 				"$comment": "WES v3 per ngs-api PR #55"
 			},
@@ -253,8 +257,11 @@
 				"required": ["vcf_compare"],
 				"$comment": "maintained for backwards compatibility before v2"
 			},
-	  	{ 
+	  		{ 
 				"required": ["haplotyper_targets"],
+				"not": {
+					"required": ["haplotyper_output"]
+				},
 				"$comment": "maintained for backwards compatibility before v3"
 			},
 			{ 
@@ -368,19 +375,24 @@
 	      "$ref": "artifacts/artifact_pdf.json"
 	    }
 	  },
+	  "required": [
+		  "optimal_purity_value"
+	  ],
 	"oneOf": [
 		{
 			"required": [
-				"optimal_purity_value",
 				"alternative_solutions",
 				"cp_contours"
 			],
 			"$comment": "WES v3 per ngs-api PR #55"
 		},
 		{
-			"required": [
-				"optimal_purity_value"
-			],
+			"not": {
+				"required": [
+					"alternative_solutions",
+					"cp_contours"
+				]
+			},
 			"$comment": "maintained for backwards compatibility before v3"
 		}
 	],

--- a/cidc_schemas/schemas/assays/wes_core.json
+++ b/cidc_schemas/schemas/assays/wes_core.json
@@ -49,15 +49,31 @@
 	  "description": "Clonality output files.",
 	  "properties": {
 	    "clonality_pyclone": {
-	      "$ref": "artifacts/artifact_tsv.json"
+	    	"$ref": "artifacts/artifact_tsv.json",
+			"$comment": "maintained for backwards compatibility before v3"
 	    },
 	    "clonality_table": {
-	      "$ref": "artifacts/artifact_tsv.json"
-	    }
+	    	"$ref": "artifacts/artifact_tsv.json",
+			"$comment": "maintained for backwards compatibility before v3"
+	    },
+		"genome_view": {
+			"$ref": "artifacts/artifact_pdf.json"
+		}
 	  },
-	  "required": [
-	    "clonality_pyclone",
-	    "clonality_table"
+	  "oneOf": [
+		{
+			"required": [
+				"genome_view"
+			],
+			"$comment": "WES v3 per ngs-api PR #55"
+		},
+		{
+			"required": [
+				"clonality_pyclone",
+				"clonality_table"
+			],
+			"$comment": "maintained for backwards compatibility before v3"
+		}
 	  ],
 	  "additionalProperties": false
 	},
@@ -300,8 +316,7 @@
 				"$comment": "added for backwards compatibility"
 			},
 			"maf_tnscope_output": {
-				"$ref": "artifacts/artifact_maf.json",
-				"$comment": "added for backwards compatibility"
+				"$ref": "artifacts/artifact_maf.json"
 			},
 			"tnscope_exons": {
 				"$ref": "artifacts/artifact_vcf_gz.json",
@@ -312,13 +327,24 @@
 			{
 				"required": [
 					"vcf_gz_tnscope_output",
+					"tnscope_output_twist_filtered_vcf",
+					"tnscope_output_twist_filtered_maf",
+					"tnscope_output_twist_vcf",
+					"tnscope_output_twist_maf"
+				],
+				"$comment": "WES v3 per ngs-api PR #55"
+			},
+			{
+				"required": [
+					"vcf_gz_tnscope_output",
 					"vcf_gz_tnscope_filter",
 					"tnscope_output_twist_filtered_vcf",
 					"tnscope_output_twist_filtered_maf",
 					"maf_tnscope_filter",
 					"tnscope_output_twist_vcf",
 					"tnscope_output_twist_maf"
-				]
+				],
+				"$comment": "maintained for backwards compatibility before v3"
 			},
 			{
 				"required": [
@@ -328,7 +354,7 @@
 					"maf_tnscope_output",
 					"tnscope_exons"
 				],
-				"$comment": "added for backwards compatibility"
+				"$comment": "maintained for backwards compatibility before v2"
 			}
 		]
 	}

--- a/cidc_schemas/schemas/assays/wes_core.json
+++ b/cidc_schemas/schemas/assays/wes_core.json
@@ -37,10 +37,24 @@
 	      "$ref": "artifacts/artifact_bam_bai.json"
 	    }
 	  },
-	  "required": [
-	    "align_sorted_dedup",
-	    "align_sorted_dedup_index"
-	  ],
+	  "oneOf": [
+		{
+			"required": [
+				"align_sorted_dedup",
+				"align_sorted_dedup_index",
+				"align_recalibrated",
+				"align_recalibrated_index"
+			],
+			"$comment": "WES v3 per ngs-api PR #55"
+		},
+		{
+			"required": [
+				"align_sorted_dedup",
+				"align_sorted_dedup_index"
+			],
+			"$comment": "maintained for backwards compatibility before v3"
+		}
+		],
 	  "additionalProperties": false
 	},
 
@@ -56,14 +70,38 @@
 	    	"$ref": "artifacts/artifact_tsv.json",
 			"$comment": "maintained for backwards compatibility before v3"
 	    },
-		"genome_view": {
-			"$ref": "artifacts/artifact_pdf.json"
-		}
+			"clonality_input": {
+				"$ref": "artifacts/artifact_tsv.json"
+			},
+			"clonality_results": {
+				"$ref": "artifacts/artifact_tsv.json"
+			},
+			"clonality_summary": {
+				"$ref": "artifacts/artifact_tsv.json"
+			},
+			"clonality_cnv_segments": {
+				"$ref": "artifacts/artifact_cns.json"
+			},
+			"clonality_cnv_segments_enhanced": {
+				"$ref": "artifacts/artifact_cns.json"
+			},
+			"clonality_cnv_scatterplot": {
+				"$ref": "artifacts/artifact_png.json"
+			},
+			"clonality_cnvkit_gainloss": {
+				"$ref": "artifacts/artifact_bed.json"
+			}
 	  },
 	  "oneOf": [
 		{
 			"required": [
-				"genome_view"
+				"clonality_input",
+				"clonality_results",
+				"clonality_summary",
+				"clonality_cnv_segments",
+				"clonality_cnv_segments_enhanced",
+				"clonality_cnv_scatterplot",
+				"clonality_cnvkit_gainloss"
 			],
 			"$comment": "WES v3 per ngs-api PR #55"
 		},
@@ -83,16 +121,68 @@
 	  "description": "Copy number output files.",
 	  "properties": {
 	    "copynumber_cnv_calls": {
-	      "$ref": "artifacts/artifact_text.json"
+	      "$ref": "artifacts/artifact_text.json",
+				"$comment": "maintained for backwards compatibility before v3"
 	    },
 	    "copynumber_cnv_calls_tsv": {
-	      "$ref": "artifacts/artifact_tsv.json"
-	    }
+	      "$ref": "artifacts/artifact_tsv.json",
+				"$comment": "maintained for backwards compatibility before v3"
+	    },
+			"copynumber_segments": {
+				"$ref": "artifacts/artifact_text.json"
+			},
+			"copynumber_genome_view": {
+				"$ref": "artifacts/artifact_pdf.json"
+			},
+			"copynumber_chromosome_view": {
+				"$ref": "artifacts/artifact_pdf.json"
+			},
+			"copynumber_sequenza_gainloss": {
+				"$ref": "artifacts/artifact_bed.json"
+			},
+			"copynumber_sequenza_final": {
+				"$ref": "artifacts/artifact_gz.json"
+			},
+			"copynumber_consensus": {
+				"$ref": "artifacts/artifact_bed.json"
+			},
+			"copynumber_consensus_gain": {
+				"$ref": "artifacts/artifact_bed.json"
+			},
+			"copynumber_consensus_loss": {
+				"$ref": "artifacts/artifact_bed.json"
+			},
+			"copynumber_facets": {
+				"$ref": "artifacts/artifact_cncf.json"
+			},
+			"copynumber_facets_gainloss": {
+				"$ref": "artifacts/artifact_bed.json"
+			}
 	  },
-	  "required": [
-	    "copynumber_cnv_calls",
-	    "copynumber_cnv_calls_tsv"
-	  ],
+		"oneOf": [
+			{
+				"required": [
+					"copynumber_segments",
+					"copynumber_genome_view",
+					"copynumber_chromosome_view",
+					"copynumber_sequenza_gainloss",
+					"copynumber_sequenza_final",
+					"copynumber_consensus",
+					"copynumber_consensus_gain",
+					"copynumber_consensus_loss",
+					"copynumber_facets",
+					"copynumber_factes_gainloss"
+				],
+				"$comment": "WES v3 per ngs-api PR #55"
+			},
+			{
+				"required": [
+					"copynumber_cnv_calls",
+					"copynumber_cnv_calls_tsv"
+				],
+				"$comment": "maintained for backwards compatibility before v3"
+			}
+		],
 	  "additionalProperties": false
 	},
 
@@ -141,10 +231,6 @@
 	      "$ref": "artifacts/artifact_text.json"
 	    }
 	  },
-	  "required": [
-	    "coverage_metrics",
-	    "target_metrics"
-	  ],
 	  "additionalProperties": false
 	},
 
@@ -157,13 +243,52 @@
 	    },
 	    "haplotyper_targets": {
 	      "$ref": "artifacts/artifact_vcf_gz.json"
+	  	},
+			"haplotyper_output": {
+	      "$ref": "artifacts/artifact_vcf.json"
 	  	}
 	  },
 	  "oneOf": [
-	  	{ "required": ["vcf_compare"] },
-	  	{ "required": ["haplotyper_targets"] }
+	  	{ 
+				"required": ["vcf_compare"],
+				"$comment": "maintained for backwards compatibility before v2"
+			},
+	  	{ 
+				"required": ["haplotyper_targets"],
+				"$comment": "maintained for backwards compatibility before v3"
+			},
+			{ 
+				"required": [
+					"haplotyper_targets",
+					"haplotyper_output"
+				],
+				"$comment": "WES v3 per ngs-api PR #55"
+			}
 	  ],
 	  
+	  "additionalProperties": false
+	},
+
+	"hla": {
+	  "type": "object",
+	  "description": "HLA output files.",
+	  "properties": {
+	    "optitype_result": {
+	      "$ref": "artifacts/artifact_text.json"
+	    },
+	    "xhla_report_hla": {
+	      "$ref": "artifacts/artifact_json.json"
+	    },
+	    "hla_final_result": {
+	      "$ref": "artifacts/artifact_text.json"
+	    }
+	  },
+	  "required": [
+	    "optitype_result",
+			"xhla_report_hla",
+			"hla_final_result"
+	  ],
+		"$comment": "WES v3 per ngs-api PR #55",
 	  "additionalProperties": false
 	},
 
@@ -205,7 +330,6 @@
 	    }
 	  },
 	  "required": [
-	    "HLA_results",
 	    "combined_filtered"
 	  ],
 	  "additionalProperties": false
@@ -223,8 +347,10 @@
 	    }
 	  },
 	  "required": [
-	    "optitype_result"
+	    "optitype_result",
+			"xhla_report_hla"
 	  ],
+		"$comment": "maintained for backwards compatibility before v3",
 	  "additionalProperties": false
 	},
 
@@ -234,11 +360,30 @@
 	  "properties": {
 	    "optimal_purity_value": {
 	      "$ref": "artifacts/artifact_text.json"
+	    },
+			"alternative_solutions": {
+	      "$ref": "artifacts/artifact_text.json"
+	    },
+			"cp_contours": {
+	      "$ref": "artifacts/artifact_pdf.json"
 	    }
 	  },
-	  "required": [
-	    "optimal_purity_value"
-	  ],
+	"oneOf": [
+		{
+			"required": [
+				"optimal_purity_value",
+				"alternative_solutions",
+				"cp_contours"
+			],
+			"$comment": "WES v3 per ngs-api PR #55"
+		},
+		{
+			"required": [
+				"optimal_purity_value"
+			],
+			"$comment": "maintained for backwards compatibility before v3"
+		}
+	],
 	  "additionalProperties": false
 	},
 
@@ -310,7 +455,6 @@
 			"tnscope_output_twist_maf": {
 				"$ref": "artifacts/artifact_maf.json"
 			},
-
 			"vcf_tnscope_filter": {
 				"$ref": "artifacts/artifact_vcf.json",
 				"$comment": "added for backwards compatibility"
@@ -330,7 +474,8 @@
 					"tnscope_output_twist_filtered_vcf",
 					"tnscope_output_twist_filtered_maf",
 					"tnscope_output_twist_vcf",
-					"tnscope_output_twist_maf"
+					"tnscope_output_twist_maf",
+					"maf_tnscope_output"
 				],
 				"$comment": "WES v3 per ngs-api PR #55"
 			},
@@ -357,7 +502,23 @@
 				"$comment": "maintained for backwards compatibility before v2"
 			}
 		]
+	},
+
+	"tcell": {
+	  "type": "object",
+	  "description": "tcell fraction estimates.",
+	  "properties": {
+	    "tcellextrect": {
+	      "$ref": "artifacts/artifact_text.json"
+	    }
+	  },
+	  "required": [
+	    "tcellextrect"
+	  ],
+		"$comment": "WES v3 per ngs-api PR #55",
+	  "additionalProperties": false
 	}
+
   },
   "properties": {
 	"error": {

--- a/cidc_schemas/schemas/assays/wes_tumor_only_analysis.json
+++ b/cidc_schemas/schemas/assays/wes_tumor_only_analysis.json
@@ -31,6 +31,7 @@
         "copynumber": { "$ref": "assays/wes_core.json#definitions/copynumber" },
         "msisensor": { "$ref": "assays/wes_core.json#definitions/msisensor" },
         "rna": { "$ref": "assays/wes_core.json#definitions/rna" },
+        "tcell": { "$ref": "assays/wes_core.json#definitions/tcell" },
         "error": { "$ref": "assays/wes_core.json#properties/error" },
 
         "tumor": { "$ref": "assays/wes_assay.json#definitions/sample_analysis" },

--- a/cidc_schemas/schemas/assays/wes_tumor_only_analysis.json
+++ b/cidc_schemas/schemas/assays/wes_tumor_only_analysis.json
@@ -15,7 +15,6 @@
         "somatic",
         "report",
         "neoantigen",
-        "copynumber",
         "msisensor",
         "tumor"
       ],

--- a/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
@@ -40,6 +40,13 @@
                                     "is_artifact": 1
                                 },
                                 {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.maf'",
+                                    "merge_pointer": "/somatic/maf_tnscope_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/maf_tnscope_output.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
                                     "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.vcf.gz'",
                                     "merge_pointer": "/somatic/vcf_gz_tnscope_filter",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_gz_tnscope_filter.vcf.gz",

--- a/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_analysis_template.json
@@ -33,6 +33,218 @@
                                     "allow_empty": true
                                 },
                                 {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_segments.txt'",
+                                    "merge_pointer": "/copynumber/copynumber_segments",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_segments.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_genome_view.pdf'",
+                                    "merge_pointer": "/copynumber/copynumber_genome_view",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_genome_view.pdf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_chromosome_view.pdf'",
+                                    "merge_pointer": "/copynumber/copynumber_chromosome_view",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_chromosome_view.pdf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_sequenza_gainLoss.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_sequenza_gainloss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_sequenza_gainloss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}.bin50.final.seqz.txt.gz'",
+                                    "merge_pointer": "/copynumber/copynumber_sequenza_final",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_sequenza_final.txt.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_alternative_solutions.txt'",
+                                    "merge_pointer": "/purity/alternative_solutions",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/alternative_solutions.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_CP_contours.pdf'",
+                                    "merge_pointer": "/purity/cp_contours",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/cp_contours.pdf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone6.input.tsv'",
+                                    "merge_pointer": "/clonality/clonality_input",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_input.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone6.results.tsv'",
+                                    "merge_pointer": "/clonality/clonality_results",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_results.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone6.results.summary.tsv'",
+                                    "merge_pointer": "/clonality/clonality_summary",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_summary.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}.call.cns'",
+                                    "merge_pointer": "/clonality/clonality_cnv_segments",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnv_segments.cns",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}.call.enhanced.cns'",
+                                    "merge_pointer": "/clonality/clonality_cnv_segments_enhanced",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnv_segments_enhanced.cns",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}.scatter.png'",
+                                    "merge_pointer": "/clonality/clonality_cnv_scatterplot",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnv_scatterplot.png",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}_cnvkit_gainLoss.bed'",
+                                    "merge_pointer": "/clonality/clonality_cnvkit_gainloss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnvkit_gainloss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_consensus.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_consensus",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_consensus.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_consensus_merged_GAIN.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_consensus_gain",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_consensus_gain.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_consensus_merged_LOSS.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_consensus_loss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_consensus_loss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor2.txt'",
+                                    "merge_pointer": "/msisensor/msisensor",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/msisensor.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/neoantigen/{run}/combined/{run}.filtered.tsv'",
+                                    "merge_pointer": "/neoantigen/combined_filtered",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/combined_filtered.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}.optimalpurityvalue.txt'",
+                                    "merge_pointer": "/purity/optimal_purity_value",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/optimal_purity_value.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}.cncf'",
+                                    "merge_pointer": "/copynumber/copynumber_facets",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_facets.cncf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}_facets_gainLoss.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_facets_gainloss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_facets_gainloss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report.tar.gz'",
+                                    "merge_pointer": "/report/report",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/report.tar.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/somatic_variants/05_tumor_germline_overlap.tsv'",
+                                    "merge_pointer": "/report/tumor_germline_overlap",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor_germline_overlap.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/WES_Meta/02_WES_Run_Version.tsv'",
+                                    "merge_pointer": "/report/wes_run_version",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_run_version.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/config.yaml'",
+                                    "merge_pointer": "/report/config",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/config.yaml",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/metasheet.csv'",
+                                    "merge_pointer": "/report/metasheet",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/metasheet.csv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/json/{run}.wes.json'",
+                                    "merge_pointer": "/report/wes_sample_json",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_sample.json",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
+                                    "merge_pointer": "/rna/haplotyper",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/haplotyper.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.output.twist.neoantigen.vep.rna.vcf'",
+                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
                                     "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.vcf.gz'",
                                     "merge_pointer": "/somatic/vcf_gz_tnscope_output",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_gz_tnscope_output.vcf.gz",
@@ -43,20 +255,6 @@
                                     "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.maf'",
                                     "merge_pointer": "/somatic/maf_tnscope_output",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/maf_tnscope_output.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.vcf.gz'",
-                                    "merge_pointer": "/somatic/vcf_gz_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_gz_tnscope_filter.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.maf'",
-                                    "merge_pointer": "/somatic/maf_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/maf_tnscope_filter.maf",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -89,123 +287,9 @@
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/germline/{run}/{run}_vcfcompare.txt'",
-                                    "merge_pointer": "/germline/vcf_compare",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_compare.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/somatic_variants/05_tumor_germline_overlap.tsv'",
-                                    "merge_pointer": "/report/tumor_germline_overlap",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor_germline_overlap.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/neoantigens/01_HLA_Results.tsv'",
-                                    "merge_pointer": "/neoantigen/HLA_results",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/HLA_results.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/neoantigen/{run}/combined/{run}.filtered.tsv'",
-                                    "merge_pointer": "/neoantigen/combined_filtered",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/combined_filtered.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}.optimalpurityvalue.txt'",
-                                    "merge_pointer": "/purity/optimal_purity_value",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/optimal_purity_value.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone.tsv'",
-                                    "merge_pointer": "/clonality/clonality_pyclone",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_pyclone.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_table.tsv'",
-                                    "merge_pointer": "/clonality/clonality_table",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_table.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_cnvcalls.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt.tn.tsv'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls_tsv",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_cnvcalls.txt.tn.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor.txt'",
-                                    "merge_pointer": "/msisensor/msisensor",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/msisensor.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
-                                    "merge_pointer": "/rna/haplotyper",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/haplotyper.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.filter.neoantigen.vep.rna.vcf'",
-                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report.tar.gz'",
-                                    "merge_pointer": "/report/report",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/report.tar.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/WES_Meta/02_WES_Run_Version.tsv'",
-                                    "merge_pointer": "/report/wes_run_version",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_run_version.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/config.yaml'",
-                                    "merge_pointer": "/report/config",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/config.yaml",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/metasheet.csv'",
-                                    "merge_pointer": "/report/metasheet",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/metasheet.csv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/json/{run}.wes.json'",
-                                    "merge_pointer": "/report/wes_sample_json",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_sample.json",
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/tcellextrect/{run}/{run}_tcellextrect.txt'",
+                                    "merge_pointer": "/tcell/tcellextrect",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tcellextrect.txt",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }
@@ -228,39 +312,25 @@
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/sorted.dedup.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
-                                },
+                                },                
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
-                                    "merge_pointer": "/normal/optitype/optitype_result",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/optitype_result.tsv",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam'",
+                                    "merge_pointer": "/normal/alignment/align_recalibrated",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/recalibrated.bam",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
-                                    "merge_pointer": "/normal/optitype/xhla_report_hla",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/xhla_report_hla.json",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam.bai'",
+                                    "merge_pointer": "/normal/alignment/align_recalibrated_index",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/recalibrated.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.txt'",
-                                    "merge_pointer": "/normal/metrics/coverage_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/coverage_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_target_metrics.txt'",
-                                    "merge_pointer": "/normal/metrics/target_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/target_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.sample_summary.txt'",
-                                    "merge_pointer": "/normal/metrics/coverage_metrics_summary",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/coverage_metrics_summary.txt",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.output.vcf'",
+                                    "merge_pointer": "/normal/germline/haplotyper_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/haplotyper_output.vcf",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -268,6 +338,27 @@
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.targets.vcf.gz'",
                                     "merge_pointer": "/normal/germline/haplotyper_targets",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/haplotyper_targets.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/hlahd/{id}/result/{id}_final.result.txt'",
+                                    "merge_pointer": "/normal/hla/hla_final_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/hla_final_result.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
+                                    "merge_pointer": "/normal/hla/optitype_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/optitype_result.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
+                                    "merge_pointer": "/normal/hla/xhla_report_hla",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/xhla_report_hla.json",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }
@@ -290,39 +381,25 @@
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/sorted.dedup.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
-                                },
+                                },                
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
-                                    "merge_pointer": "/tumor/optitype/optitype_result",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/optitype_result.tsv",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
-                                    "merge_pointer": "/tumor/optitype/xhla_report_hla",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/xhla_report_hla.json",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam.bai'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated_index",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_target_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/target_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/target_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.sample_summary.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics_summary",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics_summary.txt",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.output.vcf'",
+                                    "merge_pointer": "/tumor/germline/haplotyper_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/haplotyper_output.vcf",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -330,6 +407,27 @@
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.targets.vcf.gz'",
                                     "merge_pointer": "/tumor/germline/haplotyper_targets",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/haplotyper_targets.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/hlahd/{id}/result/{id}_final.result.txt'",
+                                    "merge_pointer": "/tumor/hla/hla_final_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/hla_final_result.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
+                                    "merge_pointer": "/tumor/hla/optitype_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/optitype_result.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
+                                    "merge_pointer": "/tumor/hla/xhla_report_hla",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/xhla_report_hla.json",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }

--- a/cidc_schemas/schemas/templates/analyses/wes_tumor_only_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_tumor_only_analysis_template.json
@@ -33,65 +33,9 @@
                                     "allow_empty": true
                                 },
                                 {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.vcf.gz'",
-                                    "merge_pointer": "/somatic/vcf_gz_tnscope_output",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_gz_tnscope_output.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.maf'",
-                                    "merge_pointer": "/somatic/maf_tnscope_output",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/maf_tnscope_output.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.vcf.gz'",
-                                    "merge_pointer": "/somatic/vcf_gz_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_gz_tnscope_filter.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.maf'",
-                                    "merge_pointer": "/somatic/maf_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/maf_tnscope_filter.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.vcf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_vcf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.maf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_maf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.vcf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_vcf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.maf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_maf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/neoantigens/01_HLA_Results.tsv'",
-                                    "merge_pointer": "/neoantigen/HLA_results",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/HLA_results.tsv",
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor2.txt'",
+                                    "merge_pointer": "/msisensor/msisensor",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/msisensor.txt",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -101,43 +45,6 @@
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/combined_filtered.tsv",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/copynumber_cnvcalls.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt.tn.tsv'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls_tsv",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/copynumber_cnvcalls.txt.tn.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor.txt'",
-                                    "merge_pointer": "/msisensor/msisensor",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/msisensor.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
-                                    "merge_pointer": "/rna/haplotyper",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/haplotyper.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.filter.neoantigen.vep.rna.vcf'",
-                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
                                 },
                                 {
                                     "parse_through": "lambda run: f'{folder or \"\"}analysis/report.tar.gz'",
@@ -173,6 +80,71 @@
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/wes_sample.json",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
+                                    "merge_pointer": "/rna/haplotyper",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/haplotyper.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.output.twist.neoantigen.vep.rna.vcf'",
+                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.vcf.gz'",
+                                    "merge_pointer": "/somatic/vcf_gz_tnscope_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_gz_tnscope_output.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.maf'",
+                                    "merge_pointer": "/somatic/maf_tnscope_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/maf_tnscope_output.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.vcf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_vcf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.maf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_maf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.vcf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_vcf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.maf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_maf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/tcellextrect/{run}/{run}_tcellextrect.txt'",
+                                    "merge_pointer": "/tcell/tcellextrect",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tcellextrect.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
                                 }
                             ]
                         },
@@ -193,39 +165,39 @@
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/sorted.dedup.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
+                                },                
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam.bai'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated_index",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam.bai",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/hlahd/{id}/result/{id}_final.result.txt'",
+                                    "merge_pointer": "/tumor/hla/hla_final_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/hla_final_result.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
                                 },
                                 {
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
-                                    "merge_pointer": "/tumor/optitype/optitype_result",
+                                    "merge_pointer": "/tumor/hla/optitype_result",
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/optitype_result.tsv",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
-                                    "merge_pointer": "/tumor/optitype/xhla_report_hla",
+                                    "merge_pointer": "/tumor/hla/xhla_report_hla",
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/xhla_report_hla.json",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_target_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/target_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/target_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.sample_summary.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics_summary",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics_summary.txt",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }

--- a/cidc_schemas/schemas/templates/analyses/wes_tumor_only_analysis_template.json
+++ b/cidc_schemas/schemas/templates/analyses/wes_tumor_only_analysis_template.json
@@ -40,6 +40,13 @@
                                     "is_artifact": 1
                                 },
                                 {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.maf'",
+                                    "merge_pointer": "/somatic/maf_tnscope_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/maf_tnscope_output.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
                                     "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.vcf.gz'",
                                     "merge_pointer": "/somatic/vcf_gz_tnscope_filter",
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_gz_tnscope_filter.vcf.gz",

--- a/cidc_schemas/template.py
+++ b/cidc_schemas/template.py
@@ -55,6 +55,10 @@ POSSIBLE_FILE_EXTS = [
     "maf",
     "tar",
     "junction",
+    "pdf",
+    "png",
+    "cns",
+    "cncf",
 ]
 
 
@@ -291,12 +295,34 @@ def _calc_merge_pointer(file_path: str, context: dict, key: str):
     # specialty conversions for existing non-standard usage
     # all text should be lowercase
     fixes = {  # old : new
+        # WES V3
+        "output.twist.neoantigen": "filter.neoantigen",
+        "optitype/result": "hla/optitype_result",
+        "tcellextrect/": "tcell/",
+        "hlahd/result/": "hla/hla",
+        "xhla/": "hla/xhla",
+        "clonality/segments": "copynumber/segments",
+        "clonality/genome": "copynumber/genome",
+        "clonality/chromosome": "copynumber/chromosome",
+        "clonality/sequenza": "copynumber/sequenza",
+        "clonality/facets": "copynumber/facets",
+        "clonality/bin50": "copynumber/sequenza_final",
+        "consensus_merged": "consensus",
+        "clonality/alternative": "purity/alternative",
+        "clonality/cp": "purity/cp",
+        "clonality/pyclone6": "clonality/",
+        "clonality/results.summary": "clonality/summary",
+        "cnvkit/call": "clonality/cnv_segments",
+        "cnvkit/scatter": "clonality/cnv_scatterplot",
+        "cnvkit/": "clonality/",
+        "purity/cncf": "copynumber/facets",
+        "purity/facets": "copynumber/facets",
+        "/align/recalibrated": "/alignment/align_recalibrated",
+        # Pre WES V3
         ".bam.bai": ".bam.index",
         "clonality/": "clonality/clonality/",
         "copynumber/": "copynumber/copynumber_",
         "tn_corealigned.bam": "tn_corealigned",
-        "optitype/result": "optitype/optitype_result",
-        "xhla": "optitype/xhla",
         "all_samples_summaries": "all_summaries",
         "/align/sorted.dedup": "/alignment/align_sorted_dedup",
         "sample_summar": "summar",
@@ -509,6 +535,7 @@ def _convert_api_to_template(name: str, schema: dict, assay_schema: dict):
                     # if incorrect, will still error in next step
                     continue
                 else:
+                    print(file_path)
                     raise ValueError("Generated pointer to non-existant merge_target")
 
             # GCS URI start is static

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ deepdiff~=4.3.0
 jsonpointer==2.0
 pandas==1.2.4
 jinja2~=3.0.3
-cidc-ngs-pipeline-api==0.1.18
+cidc-ngs-pipeline-api==0.1.19
 markupsafe==2.0.1
 regex==2022.3.2

--- a/tests/data/schemas/target-templates/wes_analysis_template.json
+++ b/tests/data/schemas/target-templates/wes_analysis_template.json
@@ -33,6 +33,218 @@
                                     "allow_empty": true
                                 },
                                 {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_segments.txt'",
+                                    "merge_pointer": "/copynumber/copynumber_segments",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_segments.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_genome_view.pdf'",
+                                    "merge_pointer": "/copynumber/copynumber_genome_view",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_genome_view.pdf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_chromosome_view.pdf'",
+                                    "merge_pointer": "/copynumber/copynumber_chromosome_view",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_chromosome_view.pdf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_sequenza_gainLoss.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_sequenza_gainloss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_sequenza_gainloss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}.bin50.final.seqz.txt.gz'",
+                                    "merge_pointer": "/copynumber/copynumber_sequenza_final",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_sequenza_final.txt.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_alternative_solutions.txt'",
+                                    "merge_pointer": "/purity/alternative_solutions",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/alternative_solutions.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_CP_contours.pdf'",
+                                    "merge_pointer": "/purity/cp_contours",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/cp_contours.pdf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone6.input.tsv'",
+                                    "merge_pointer": "/clonality/clonality_input",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_input.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone6.results.tsv'",
+                                    "merge_pointer": "/clonality/clonality_results",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_results.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone6.results.summary.tsv'",
+                                    "merge_pointer": "/clonality/clonality_summary",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_summary.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}.call.cns'",
+                                    "merge_pointer": "/clonality/clonality_cnv_segments",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnv_segments.cns",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}.call.enhanced.cns'",
+                                    "merge_pointer": "/clonality/clonality_cnv_segments_enhanced",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnv_segments_enhanced.cns",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}.scatter.png'",
+                                    "merge_pointer": "/clonality/clonality_cnv_scatterplot",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnv_scatterplot.png",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/cnvkit/{run}/{run}_cnvkit_gainLoss.bed'",
+                                    "merge_pointer": "/clonality/clonality_cnvkit_gainloss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_cnvkit_gainloss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_consensus.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_consensus",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_consensus.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_consensus_merged_GAIN.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_consensus_gain",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_consensus_gain.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_consensus_merged_LOSS.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_consensus_loss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_consensus_loss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor2.txt'",
+                                    "merge_pointer": "/msisensor/msisensor",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/msisensor.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/neoantigen/{run}/combined/{run}.filtered.tsv'",
+                                    "merge_pointer": "/neoantigen/combined_filtered",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/combined_filtered.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}.optimalpurityvalue.txt'",
+                                    "merge_pointer": "/purity/optimal_purity_value",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/optimal_purity_value.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}.cncf'",
+                                    "merge_pointer": "/copynumber/copynumber_facets",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_facets.cncf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}_facets_gainLoss.bed'",
+                                    "merge_pointer": "/copynumber/copynumber_facets_gainloss",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_facets_gainloss.bed",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report.tar.gz'",
+                                    "merge_pointer": "/report/report",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/report.tar.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/somatic_variants/05_tumor_germline_overlap.tsv'",
+                                    "merge_pointer": "/report/tumor_germline_overlap",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor_germline_overlap.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/WES_Meta/02_WES_Run_Version.tsv'",
+                                    "merge_pointer": "/report/wes_run_version",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_run_version.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/config.yaml'",
+                                    "merge_pointer": "/report/config",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/config.yaml",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/metasheet.csv'",
+                                    "merge_pointer": "/report/metasheet",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/metasheet.csv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/json/{run}.wes.json'",
+                                    "merge_pointer": "/report/wes_sample_json",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_sample.json",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
+                                    "merge_pointer": "/rna/haplotyper",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/haplotyper.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.output.twist.neoantigen.vep.rna.vcf'",
+                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
                                     "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.vcf.gz'",
                                     "merge_pointer": "/somatic/vcf_gz_tnscope_output",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_gz_tnscope_output.vcf.gz",
@@ -40,16 +252,9 @@
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.vcf.gz'",
-                                    "merge_pointer": "/somatic/vcf_gz_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_gz_tnscope_filter.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.maf'",
-                                    "merge_pointer": "/somatic/maf_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/maf_tnscope_filter.maf",
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.maf'",
+                                    "merge_pointer": "/somatic/maf_tnscope_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/maf_tnscope_output.maf",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -82,123 +287,9 @@
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/germline/{run}/{run}_vcfcompare.txt'",
-                                    "merge_pointer": "/germline/vcf_compare",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_compare.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/somatic_variants/05_tumor_germline_overlap.tsv'",
-                                    "merge_pointer": "/report/tumor_germline_overlap",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor_germline_overlap.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/neoantigens/01_HLA_Results.tsv'",
-                                    "merge_pointer": "/neoantigen/HLA_results",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/HLA_results.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/neoantigen/{run}/combined/{run}.filtered.tsv'",
-                                    "merge_pointer": "/neoantigen/combined_filtered",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/combined_filtered.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/purity/{run}/{run}.optimalpurityvalue.txt'",
-                                    "merge_pointer": "/purity/optimal_purity_value",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/optimal_purity_value.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_pyclone.tsv'",
-                                    "merge_pointer": "/clonality/clonality_pyclone",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_pyclone.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/clonality/{run}/{run}_table.tsv'",
-                                    "merge_pointer": "/clonality/clonality_table",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/clonality_table.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_cnvcalls.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt.tn.tsv'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls_tsv",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/copynumber_cnvcalls.txt.tn.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor.txt'",
-                                    "merge_pointer": "/msisensor/msisensor",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/msisensor.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
-                                    "merge_pointer": "/rna/haplotyper",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/haplotyper.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.filter.neoantigen.vep.rna.vcf'",
-                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report.tar.gz'",
-                                    "merge_pointer": "/report/report",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/report.tar.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/WES_Meta/02_WES_Run_Version.tsv'",
-                                    "merge_pointer": "/report/wes_run_version",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_run_version.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/config.yaml'",
-                                    "merge_pointer": "/report/config",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/config.yaml",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/metasheet.csv'",
-                                    "merge_pointer": "/report/metasheet",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/metasheet.csv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/json/{run}.wes.json'",
-                                    "merge_pointer": "/report/wes_sample_json",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/wes_sample.json",
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/tcellextrect/{run}/{run}_tcellextrect.txt'",
+                                    "merge_pointer": "/tcell/tcellextrect",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tcellextrect.txt",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }
@@ -221,39 +312,25 @@
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/sorted.dedup.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
-                                },
+                                },                
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
-                                    "merge_pointer": "/normal/optitype/optitype_result",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/optitype_result.tsv",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam'",
+                                    "merge_pointer": "/normal/alignment/align_recalibrated",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/recalibrated.bam",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
-                                    "merge_pointer": "/normal/optitype/xhla_report_hla",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/xhla_report_hla.json",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam.bai'",
+                                    "merge_pointer": "/normal/alignment/align_recalibrated_index",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/recalibrated.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.txt'",
-                                    "merge_pointer": "/normal/metrics/coverage_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/coverage_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_target_metrics.txt'",
-                                    "merge_pointer": "/normal/metrics/target_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/target_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.sample_summary.txt'",
-                                    "merge_pointer": "/normal/metrics/coverage_metrics_summary",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/coverage_metrics_summary.txt",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.output.vcf'",
+                                    "merge_pointer": "/normal/germline/haplotyper_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/haplotyper_output.vcf",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -261,6 +338,27 @@
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.targets.vcf.gz'",
                                     "merge_pointer": "/normal/germline/haplotyper_targets",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/haplotyper_targets.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/hlahd/{id}/result/{id}_final.result.txt'",
+                                    "merge_pointer": "/normal/hla/hla_final_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/hla_final_result.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
+                                    "merge_pointer": "/normal/hla/optitype_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/optitype_result.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
+                                    "merge_pointer": "/normal/hla/xhla_report_hla",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/normal/{normal cimac id}/xhla_report_hla.json",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }
@@ -283,39 +381,25 @@
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/sorted.dedup.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
-                                },
+                                },                
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
-                                    "merge_pointer": "/tumor/optitype/optitype_result",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/optitype_result.tsv",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
-                                    "merge_pointer": "/tumor/optitype/xhla_report_hla",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/xhla_report_hla.json",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam.bai'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated_index",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_target_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/target_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/target_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.sample_summary.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics_summary",
-                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics_summary.txt",
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.output.vcf'",
+                                    "merge_pointer": "/tumor/germline/haplotyper_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/haplotyper_output.vcf",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -323,6 +407,27 @@
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/germline/{id}/{id}_haplotyper.targets.vcf.gz'",
                                     "merge_pointer": "/tumor/germline/haplotyper_targets",
                                     "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/haplotyper_targets.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/hlahd/{id}/result/{id}_final.result.txt'",
+                                    "merge_pointer": "/tumor/hla/hla_final_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/hla_final_result.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
+                                    "merge_pointer": "/tumor/hla/optitype_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/optitype_result.tsv",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
+                                    "merge_pointer": "/tumor/hla/xhla_report_hla",
+                                    "gcs_uri_format": "{protocol identifier}/wes/{run id}/analysis/tumor/{tumor cimac id}/xhla_report_hla.json",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }

--- a/tests/data/schemas/target-templates/wes_tumor_only_analysis_template.json
+++ b/tests/data/schemas/target-templates/wes_tumor_only_analysis_template.json
@@ -33,58 +33,9 @@
                                     "allow_empty": true
                                 },
                                 {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.vcf.gz'",
-                                    "merge_pointer": "/somatic/vcf_gz_tnscope_output",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_gz_tnscope_output.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.vcf.gz'",
-                                    "merge_pointer": "/somatic/vcf_gz_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_gz_tnscope_filter.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.filter.maf'",
-                                    "merge_pointer": "/somatic/maf_tnscope_filter",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/maf_tnscope_filter.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.vcf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_vcf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.maf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_maf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.vcf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_vcf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.maf'",
-                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_maf",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.maf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/report/neoantigens/01_HLA_Results.tsv'",
-                                    "merge_pointer": "/neoantigen/HLA_results",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/HLA_results.tsv",
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor2.txt'",
+                                    "merge_pointer": "/msisensor/msisensor",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/msisensor.txt",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
@@ -94,43 +45,6 @@
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/combined_filtered.tsv",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/copynumber_cnvcalls.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/copynumber/{run}/{run}_cnvcalls.txt.tn.tsv'",
-                                    "merge_pointer": "/copynumber/copynumber_cnv_calls_tsv",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/copynumber_cnvcalls.txt.tn.tsv",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/msisensor2/{run}/{run}_msisensor.txt'",
-                                    "merge_pointer": "/msisensor/msisensor",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/msisensor.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
-                                    "merge_pointer": "/rna/haplotyper",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/haplotyper.vcf.gz",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
-                                },
-                                {
-                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.filter.neoantigen.vep.rna.vcf'",
-                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1,
-                                    "allow_empty": true
                                 },
                                 {
                                     "parse_through": "lambda run: f'{folder or \"\"}analysis/report.tar.gz'",
@@ -166,6 +80,71 @@
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/wes_sample.json",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}.haplotyper.rna.vcf.gz'",
+                                    "merge_pointer": "/rna/haplotyper",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/haplotyper.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/rna/{run}/{run}_tnscope.output.twist.neoantigen.vep.rna.vcf'",
+                                    "merge_pointer": "/rna/vcf_tnscope_filter_neoantigen",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_tnscope_filter_neoantigen.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1,
+                                    "allow_empty": true
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.vcf.gz'",
+                                    "merge_pointer": "/somatic/vcf_gz_tnscope_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/vcf_gz_tnscope_output.vcf.gz",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.maf'",
+                                    "merge_pointer": "/somatic/maf_tnscope_output",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/maf_tnscope_output.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.vcf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_vcf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.maf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_maf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.vcf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_vcf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.vcf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/somatic/{run}/{run}_tnscope.output.twist.filtered.maf'",
+                                    "merge_pointer": "/somatic/tnscope_output_twist_filtered_maf",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tnscope_output_twist_filtered.maf",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda run: f'{folder or \"\"}analysis/tcellextrect/{run}/{run}_tcellextrect.txt'",
+                                    "merge_pointer": "/tcell/tcellextrect",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tcellextrect.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
                                 }
                             ]
                         },
@@ -186,39 +165,39 @@
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/sorted.dedup.bam.bai",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
+                                },                
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/align/{id}/{id}_recalibrated.bam.bai'",
+                                    "merge_pointer": "/tumor/alignment/align_recalibrated_index",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/recalibrated.bam.bai",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
+                                },
+                                {
+                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/hlahd/{id}/result/{id}_final.result.txt'",
+                                    "merge_pointer": "/tumor/hla/hla_final_result",
+                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/hla_final_result.txt",
+                                    "type_ref": "assays/components/local_file.json#properties/file_path",
+                                    "is_artifact": 1
                                 },
                                 {
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/optitype/{id}/{id}_result.tsv'",
-                                    "merge_pointer": "/tumor/optitype/optitype_result",
+                                    "merge_pointer": "/tumor/hla/optitype_result",
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/optitype_result.tsv",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 },
                                 {
                                     "parse_through": "lambda id: f'{folder or \"\"}analysis/xhla/{id}/report-{id}-hla.json'",
-                                    "merge_pointer": "/tumor/optitype/xhla_report_hla",
+                                    "merge_pointer": "/tumor/hla/xhla_report_hla",
                                     "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/xhla_report_hla.json",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_target_metrics.txt'",
-                                    "merge_pointer": "/tumor/metrics/target_metrics",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/target_metrics.txt",
-                                    "type_ref": "assays/components/local_file.json#properties/file_path",
-                                    "is_artifact": 1
-                                },
-                                {
-                                    "parse_through": "lambda id: f'{folder or \"\"}analysis/metrics/{id}/{id}_coverage_metrics.sample_summary.txt'",
-                                    "merge_pointer": "/tumor/metrics/coverage_metrics_summary",
-                                    "gcs_uri_format": "{protocol identifier}/wes_tumor_only/{run id}/analysis/tumor/{tumor cimac id}/coverage_metrics_summary.txt",
                                     "type_ref": "assays/components/local_file.json#properties/file_path",
                                     "is_artifact": 1
                                 }

--- a/tests/prism/cidc_test_data/analysis_data.py
+++ b/tests/prism/cidc_test_data/analysis_data.py
@@ -35,11 +35,26 @@ def wes_analysis() -> PrismTestData:
                             "upload_placeholder": "cdef9e1e-8e04-46ed-a9e6-bb618188a6d7"
                         },
                         "clonality": {
-                            "clonality_pyclone": {
+                            "clonality_input": {
                                 "upload_placeholder": "cdef9e1e-8e04-46ed-a9e6-bb618188a6d6"
                             },
-                            "clonality_table": {
+                            "clonality_results": {
                                 "upload_placeholder": "ctef9e1e-8e04-46ed-a9e6-bb618188a6d6"
+                            },
+                            "clonality_summary": {
+                                "upload_placeholder": "dtef9e1e-8e04-46ed-a9e6-bb618188a6d6"
+                            },
+                            "clonality_cnv_segments": {
+                                "upload_placeholder": "etef9e1e-8e04-46ed-a9e6-bb618188a6d6"
+                            },
+                            "clonality_cnv_segments_enhanced": {
+                                "upload_placeholder": "ftef9e1e-8e04-46ed-a9e6-bb618188a6d6"
+                            },
+                            "clonality_cnv_scatterplot": {
+                                "upload_placeholder": "gtef9e1e-8e04-46ed-a9e6-bb618188a6d6"
+                            },
+                            "clonality_cnvkit_gainloss": {
+                                "upload_placeholder": "htef9e1e-8e04-46ed-a9e6-bb618188a6d6"
                             },
                         },
                         "msisensor": {
@@ -48,95 +63,51 @@ def wes_analysis() -> PrismTestData:
                             }
                         },
                         "copynumber": {
-                            "copynumber_cnv_calls": {
+                            "copynumber_segments": {
                                 "upload_placeholder": "85989077-49e4-44c6-8788-3b19357d3122"
                             },
-                            "copynumber_cnv_calls_tsv": {
+                            "copynumber_genome_view": {
                                 "upload_placeholder": "eb1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_chromosome_view": {
+                                "upload_placeholder": "fb1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_sequenza_gainloss": {
+                                "upload_placeholder": "gb1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_sequenza_final": {
+                                "upload_placeholder": "hb1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_consensus": {
+                                "upload_placeholder": "ib1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_consensus_gain": {
+                                "upload_placeholder": "jb1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_consensus_loss": {
+                                "upload_placeholder": "kb1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_facets": {
+                                "upload_placeholder": "lb1a8d7a-fd96-4e75-b265-1590c703a301"
+                            },
+                            "copynumber_facets_gainloss": {
+                                "upload_placeholder": "mb1a8d7a-fd96-4e75-b265-1590c703a301"
                             },
                         },
                         "neoantigen": {
-                            "HLA_results": {
-                                "upload_placeholder": "e47271fb-e2c7-5436-cafe-5cf84bc72bf6"
-                            },
                             "combined_filtered": {
                                 "upload_placeholder": "f47271fb-e2c7-5436-cafe-5cf84bc72bf7"
-                            },
-                        },
-                        "somatic": {
-                            "vcf_gz_tnscope_filter": {
-                                "upload_placeholder": "b86ab142-a925-433c-bb13-030c0684365e"
-                            },
-                            "vcf_gz_tnscope_output": {
-                                "upload_placeholder": "c86ab142-a925-433c-bb13-030c0684365f"
-                            },
-                            "maf_tnscope_filter": {
-                                "upload_placeholder": "53991cf3-b1b9-4b4a-830d-5eade9ef1321"
-                            },
-                            "tnscope_output_twist_vcf": {
-                                "upload_placeholder": "99966c04-86f8-44af-953d-0cfb10d11b99"
-                            },
-                            "tnscope_output_twist_filtered_vcf": {
-                                "upload_placeholder": "88866c04-86f8-44af-953d-0cfb10d11b88"
-                            },
-                            "tnscope_output_twist_filtered_maf": {
-                                "upload_placeholder": "777b8502-d7cc-4002-a96d-57e635f4f277"
-                            },
-                            "tnscope_output_twist_maf": {
-                                "upload_placeholder": "66689bba-708c-449f-879f-44cba199c666"
                             },
                         },
                         "purity": {
                             "optimal_purity_value": {
                                 "upload_placeholder": "f0b85ef8-47cb-45b9-bb94-c961150786b9"
-                            }
-                        },
-                        "germline": {
-                            "vcf_compare": {
-                                "upload_placeholder": "218be905-220d-417f-8395-0de84fcd81sg"
-                            }
-                        },
-                        "rna": {
-                            "haplotyper": {
-                                "upload_placeholder": "e0b85ef8-47cb-45b9-bb94-c961150786b9"
                             },
-                            "vcf_tnscope_filter_neoantigen": {
-                                "upload_placeholder": "d0b85ef8-47cb-45b9-bb94-c961150786b9"
+                            "cp_contours": {
+                                "upload_placeholder": "b86ab142-a925-433c-bb13-030c0684365e"
                             },
-                        },
-                        "tumor": {
-                            "metrics": {
-                                "coverage_metrics": {
-                                    "upload_placeholder": "1ac21de4-6b15-48c0-9a0a-d66b9d99cd49"
-                                },
-                                "target_metrics": {
-                                    "upload_placeholder": "2bdcbe60-09d5-4f98-a1fc-01c374c147f5"
-                                },
-                                "coverage_metrics_summary": {
-                                    "upload_placeholder": "653bd098-3997-494b-8db9-03d114b3fbb3"
-                                },
-                            },
-                            "cimac_id": "CTTTPP111.00",
-                            "alignment": {
-                                "align_sorted_dedup": {
-                                    "upload_placeholder": "2068ae50-3ce7-4b0c-ba56-f678233dd098"
-                                },
-                                "align_sorted_dedup_index": {
-                                    "upload_placeholder": "cc4ce43e-bc4f-4a93-b482-454f874421a8"
-                                },
-                            },
-                            "optitype": {
-                                "optitype_result": {
-                                    "upload_placeholder": "a5899d73-7373-4041-85f9-6cc4324be817"
-                                },
-                                "xhla_report_hla": {
-                                    "upload_placeholder": "2f3307bd-960e-4735-b831-f93d20fe8d37"
-                                },
-                            },
-                            "germline": {
-                                "haplotyper_targets": {
-                                    "upload_placeholder": "ht899d73-7373-4041-85f9-6cc4324be811"
-                                }
+                            "alternative_solutions": {
+                                "upload_placeholder": "c86ab142-a925-433c-bb13-030c0684365e"
                             },
                         },
                         "report": {
@@ -159,6 +130,75 @@ def wes_analysis() -> PrismTestData:
                                 "upload_placeholder": "yyz24763-fb9f-58b4-c7c4-8175759933s1"
                             },
                         },
+                        "rna": {
+                            "haplotyper": {
+                                "upload_placeholder": "e0b85ef8-47cb-45b9-bb94-c961150786b9"
+                            },
+                            "vcf_tnscope_filter_neoantigen": {
+                                "upload_placeholder": "d0b85ef8-47cb-45b9-bb94-c961150786b9"
+                            },
+                        },
+                        "somatic": {
+                            "vcf_gz_tnscope_output": {
+                                "upload_placeholder": "c86ab142-a925-433c-bb13-030c0684365f"
+                            },
+                            "maf_tnscope_output": {
+                                "upload_placeholder": "53991cf3-b1b9-4b4a-830d-5eade9ef1321"
+                            },
+                            "tnscope_output_twist_vcf": {
+                                "upload_placeholder": "99966c04-86f8-44af-953d-0cfb10d11b99"
+                            },
+                            "tnscope_output_twist_maf": {
+                                "upload_placeholder": "66689bba-708c-449f-879f-44cba199c666"
+                            },
+                            "tnscope_output_twist_filtered_vcf": {
+                                "upload_placeholder": "88866c04-86f8-44af-953d-0cfb10d11b88"
+                            },
+                            "tnscope_output_twist_filtered_maf": {
+                                "upload_placeholder": "777b8502-d7cc-4002-a96d-57e635f4f277"
+                            },
+                        },
+                        "tcell": {
+                            "tcellextrect": {
+                                "upload_placeholder": "653bd098-3997-494b-8db9-03d114b3fbb3"
+                            }
+                        },
+                        "tumor": {
+                            "cimac_id": "CTTTPP111.00",
+                            "alignment": {
+                                "align_sorted_dedup": {
+                                    "upload_placeholder": "2068ae50-3ce7-4b0c-ba56-f678233dd098"
+                                },
+                                "align_sorted_dedup_index": {
+                                    "upload_placeholder": "cc4ce43e-bc4f-4a93-b482-454f874421a8"
+                                },
+                                "align_recalibrated": {
+                                    "upload_placeholder": "dc4ce43e-bc4f-4a93-b482-454f874421a8"
+                                },
+                                "align_recalibrated_index": {
+                                    "upload_placeholder": "ec4ce43e-bc4f-4a93-b482-454f874421a8"
+                                },
+                            },
+                            "germline": {
+                                "haplotyper_targets": {
+                                    "upload_placeholder": "ht899d73-7373-4041-85f9-6cc4324be811"
+                                },
+                                "haplotyper_output": {
+                                    "upload_placeholder": "it899d73-7373-4041-85f9-6cc4324be811"
+                                },
+                            },
+                            "hla": {
+                                "hla_final_result": {
+                                    "upload_placeholder": "218be905-220d-417f-8395-0de84fcd81sg"
+                                },
+                                "optitype_result": {
+                                    "upload_placeholder": "a5899d73-7373-4041-85f9-6cc4324be817"
+                                },
+                                "xhla_report_hla": {
+                                    "upload_placeholder": "2f3307bd-960e-4735-b831-f93d20fe8d37"
+                                },
+                            },
+                        },
                         "normal": {
                             "cimac_id": "CTTTPP111.00",
                             "alignment": {
@@ -168,19 +208,17 @@ def wes_analysis() -> PrismTestData:
                                 "align_sorted_dedup_index": {
                                     "upload_placeholder": "be406c27-2ef4-477c-93e5-684fbe4f9307"
                                 },
-                            },
-                            "metrics": {
-                                "coverage_metrics": {
-                                    "upload_placeholder": "907d981b-7ca9-4bb9-a10f-ab4aa808c5a3"
+                                "align_recalibrated": {
+                                    "upload_placeholder": "d163f7aa-43ba-40f4-b11d-bddb79b41763"
                                 },
-                                "target_metrics": {
-                                    "upload_placeholder": "29b2cc56-422c-478c-8c6d-ee040ca1e6df"
-                                },
-                                "coverage_metrics_summary": {
-                                    "upload_placeholder": "3b5fded9-7274-45a4-a71e-48cf590814a9"
+                                "align_recalibrated_index": {
+                                    "upload_placeholder": "ce406c27-2ef4-477c-93e5-684fbe4f9307"
                                 },
                             },
-                            "optitype": {
+                            "hla": {
+                                "hla_final_result": {
+                                    "upload_placeholder": "7b36da9d-c015-42be-80df-d22c17a29124"
+                                },
                                 "optitype_result": {
                                     "upload_placeholder": "6b36da9d-c015-42be-80df-d22c17a29124"
                                 },
@@ -191,7 +229,10 @@ def wes_analysis() -> PrismTestData:
                             "germline": {
                                 "haplotyper_targets": {
                                     "upload_placeholder": "ht899d73-7373-4041-85f9-6cc4324be812"
-                                }
+                                },
+                                "haplotyper_output": {
+                                    "upload_placeholder": "it899d73-7373-4041-85f9-6cc4324be812"
+                                },
                             },
                         },
                     },
@@ -201,11 +242,26 @@ def wes_analysis() -> PrismTestData:
                             "upload_placeholder": "a4cba177-0be5-4d7d-b635-4a60adaa9576"
                         },
                         "clonality": {
-                            "clonality_pyclone": {
+                            "clonality_input": {
                                 "upload_placeholder": "a4cba177-0be5-4d7d-b635-4a60adaa9575"
                             },
-                            "clonality_table": {
+                            "clonality_results": {
                                 "upload_placeholder": "aucba177-0be5-4d7d-b635-4a60adaa9575"
+                            },
+                            "clonality_summary": {
+                                "upload_placeholder": "b4cba177-0be5-4d7d-b635-4a60adaa9575"
+                            },
+                            "clonality_cnv_segments": {
+                                "upload_placeholder": "bucba177-0be5-4d7d-b635-4a60adaa9575"
+                            },
+                            "clonality_cnv_segments_enhanced": {
+                                "upload_placeholder": "c4cba177-0be5-4d7d-b635-4a60adaa9575"
+                            },
+                            "clonality_cnv_scatterplot": {
+                                "upload_placeholder": "cucba177-0be5-4d7d-b635-4a60adaa9575"
+                            },
+                            "clonality_cnvkit_gainloss": {
+                                "upload_placeholder": "d4cba177-0be5-4d7d-b635-4a60adaa9575"
                             },
                         },
                         "msisensor": {
@@ -214,33 +270,54 @@ def wes_analysis() -> PrismTestData:
                             }
                         },
                         "copynumber": {
-                            "copynumber_cnv_calls": {
+                            "copynumber_segments": {
                                 "upload_placeholder": "c187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
                             },
-                            "copynumber_cnv_calls_tsv": {
+                            "copynumber_genome_view": {
                                 "upload_placeholder": "ba2984c0-f7e6-470c-95ef-e4b33cbdea48"
+                            },
+                            "copynumber_chromosome_view": {
+                                "upload_placeholder": "d187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
+                            },
+                            "copynumber_sequenza_gainloss": {
+                                "upload_placeholder": "ca2984c0-f7e6-470c-95ef-e4b33cbdea48"
+                            },
+                            "copynumber_sequenza_final": {
+                                "upload_placeholder": "e187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
+                            },
+                            "copynumber_consensus": {
+                                "upload_placeholder": "f187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
+                            },
+                            "copynumber_consensus_gain": {
+                                "upload_placeholder": "da2984c0-f7e6-470c-95ef-e4b33cbdea48"
+                            },
+                            "copynumber_consensus_loss": {
+                                "upload_placeholder": "g187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
+                            },
+                            "copynumber_facets": {
+                                "upload_placeholder": "ea2984c0-f7e6-470c-95ef-e4b33cbdea48"
+                            },
+                            "copynumber_facets_gainloss": {
+                                "upload_placeholder": "h187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
                             },
                         },
                         "neoantigen": {
-                            "HLA_results": {
-                                "upload_placeholder": "76824763-fb9f-58b4-c7c4-8175759933f6"
-                            },
                             "combined_filtered": {
                                 "upload_placeholder": "86824763-fb9f-58b4-c7c4-8175759933f7"
                             },
                         },
                         "somatic": {
-                            "vcf_gz_tnscope_filter": {
-                                "upload_placeholder": "64466c04-86f8-44af-953d-0cfb10d11b34"
-                            },
                             "vcf_gz_tnscope_output": {
                                 "upload_placeholder": "84466c04-86f8-44af-953d-0cfb10d11b36"
                             },
-                            "maf_tnscope_filter": {
-                                "upload_placeholder": "1d589bba-708c-449f-879f-44cba199c635"
+                            "maf_tnscope_output": {
+                                "upload_placeholder": "94466c04-86f8-44af-953d-0cfb10d11b36"
                             },
                             "tnscope_output_twist_vcf": {
-                                "upload_placeholder": "99466c04-86f8-44af-953d-0cfb10d11b99"
+                                "upload_placeholder": "64466c04-86f8-44af-953d-0cfb10d11b34"
+                            },
+                            "tnscope_output_twist_maf": {
+                                "upload_placeholder": "66589bba-708c-449f-879f-44cba199c666"
                             },
                             "tnscope_output_twist_filtered_vcf": {
                                 "upload_placeholder": "88466c04-86f8-44af-953d-0cfb10d11b88"
@@ -248,19 +325,17 @@ def wes_analysis() -> PrismTestData:
                             "tnscope_output_twist_filtered_maf": {
                                 "upload_placeholder": "773b8502-d7cc-4002-a96d-57e635f4f277"
                             },
-                            "tnscope_output_twist_maf": {
-                                "upload_placeholder": "66589bba-708c-449f-879f-44cba199c666"
-                            },
-                        },
-                        "germline": {
-                            "vcf_compare": {
-                                "upload_placeholder": "84f6bd4c-00db-4ce3-a6b6-a8482a3332sg"
-                            },
                         },
                         "purity": {
-                            "optimal_purity_value": {
+                            "alternative_solutions": {
                                 "upload_placeholder": "98621828-ee22-40d1-840a-0dae97e8bf09"
-                            }
+                            },
+                            "cp_contours": {
+                                "upload_placeholder": "08621828-ee22-40d1-840a-0dae97e8bf09"
+                            },
+                            "optimal_purity_value": {
+                                "upload_placeholder": "76824763-fb9f-58b4-c7c4-8175759933f6"
+                            },
                         },
                         "rna": {
                             "haplotyper": {
@@ -268,41 +343,6 @@ def wes_analysis() -> PrismTestData:
                             },
                             "vcf_tnscope_filter_neoantigen": {
                                 "upload_placeholder": "78621828-ee22-40d1-840a-0dae97e8bf09"
-                            },
-                        },
-                        "tumor": {
-                            "metrics": {
-                                "coverage_metrics": {
-                                    "upload_placeholder": "bc055607-9085-4f47-91e5-8f412c4dfafd"
-                                },
-                                "target_metrics": {
-                                    "upload_placeholder": "95e70b6a-1ddc-4bfe-84eb-6c4a6f1ee35d"
-                                },
-                                "coverage_metrics_summary": {
-                                    "upload_placeholder": "3db263fd-2b23-4905-8389-dc8c49c01c2f"
-                                },
-                            },
-                            "cimac_id": "CTTTPP121.00",
-                            "alignment": {
-                                "align_sorted_dedup": {
-                                    "upload_placeholder": "d23d0858-eabb-4e9d-ad42-9bb4edadfd59"
-                                },
-                                "align_sorted_dedup_index": {
-                                    "upload_placeholder": "ea9a388b-d679-4a77-845f-2c4073425128"
-                                },
-                            },
-                            "optitype": {
-                                "optitype_result": {
-                                    "upload_placeholder": "671d710e-f245-4d2b-8732-2774e26aec10"
-                                },
-                                "xhla_report_hla": {
-                                    "upload_placeholder": "4807aaa5-bafa-4fe5-89e9-73f9d734b971"
-                                },
-                            },
-                            "germline": {
-                                "haplotyper_targets": {
-                                    "upload_placeholder": "ht899d73-7373-4041-85f9-6cc4324be813"
-                                }
                             },
                         },
                         "report": {
@@ -325,6 +365,47 @@ def wes_analysis() -> PrismTestData:
                                 "upload_placeholder": "yyz271fb-e2c7-5436-cafe-5cf84bc72bs2"
                             },
                         },
+                        "tcell": {
+                            "tcellextrect": {
+                                "upload_placeholder": "1d589bba-708c-449f-879f-44cba199c635"
+                            }
+                        },
+                        "tumor": {
+                            "cimac_id": "CTTTPP121.00",
+                            "alignment": {
+                                "align_sorted_dedup": {
+                                    "upload_placeholder": "d23d0858-eabb-4e9d-ad42-9bb4edadfd59"
+                                },
+                                "align_sorted_dedup_index": {
+                                    "upload_placeholder": "ea9a388b-d679-4a77-845f-2c4073425128"
+                                },
+                                "align_recalibrated": {
+                                    "upload_placeholder": "e23d0858-eabb-4e9d-ad42-9bb4edadfd59"
+                                },
+                                "align_recalibrated_index": {
+                                    "upload_placeholder": "fa9a388b-d679-4a77-845f-2c4073425128"
+                                },
+                            },
+                            "germline": {
+                                "haplotyper_output": {
+                                    "upload_placeholder": "it899d73-7373-4041-85f9-6cc4324be813"
+                                },
+                                "haplotyper_targets": {
+                                    "upload_placeholder": "ht899d73-7373-4041-85f9-6cc4324be813"
+                                },
+                            },
+                            "hla": {
+                                "hla_final_result": {
+                                    "upload_placeholder": "84f6bd4c-00db-4ce3-a6b6-a8482a3332sg"
+                                },
+                                "optitype_result": {
+                                    "upload_placeholder": "671d710e-f245-4d2b-8732-2774e26aec10"
+                                },
+                                "xhla_report_hla": {
+                                    "upload_placeholder": "4807aaa5-bafa-4fe5-89e9-73f9d734b971"
+                                },
+                            },
+                        },
                         "normal": {
                             "cimac_id": "CTTTPP121.00",
                             "alignment": {
@@ -334,30 +415,31 @@ def wes_analysis() -> PrismTestData:
                                 "align_sorted_dedup_index": {
                                     "upload_placeholder": "4a06b799-2eb8-47f3-92fa-f5e21da85697"
                                 },
-                            },
-                            "metrics": {
-                                "coverage_metrics": {
-                                    "upload_placeholder": "5566abb7-6bfb-4a0f-94a3-f3b02979a131"
+                                "align_recalibrated": {
+                                    "upload_placeholder": "g2b13d18-36a2-4273-a69c-a143415231db"
                                 },
-                                "target_metrics": {
-                                    "upload_placeholder": "d92c402a-d9a5-4e6c-998d-b56b1b0b7ffa"
-                                },
-                                "coverage_metrics_summary": {
-                                    "upload_placeholder": "de83d3c9-6b0d-4317-b01e-dd28183744f7"
+                                "align_recalibrated_index": {
+                                    "upload_placeholder": "5a06b799-2eb8-47f3-92fa-f5e21da85697"
                                 },
                             },
-                            "optitype": {
+                            "germline": {
+                                "haplotyper_targets": {
+                                    "upload_placeholder": "ht899d73-7373-4041-85f9-6cc4324be814"
+                                },
+                                "haplotyper_output": {
+                                    "upload_placeholder": "it899d73-7373-4041-85f9-6cc4324be814"
+                                },
+                            },
+                            "hla": {
+                                "hla_final_result": {
+                                    "upload_placeholder": "0371d710-e3d0-4d1b-b87f-23bbadc4ae7e"
+                                },
                                 "optitype_result": {
                                     "upload_placeholder": "9371d710-e3d0-4d1b-b87f-23bbadc4ae7e"
                                 },
                                 "xhla_report_hla": {
                                     "upload_placeholder": "1d0c1f42-6a58-4e4b-b127-208c33f2aeb6"
                                 },
-                            },
-                            "germline": {
-                                "haplotyper_targets": {
-                                    "upload_placeholder": "ht899d73-7373-4041-85f9-6cc4324be814"
-                                }
                             },
                         },
                     },
@@ -379,44 +461,142 @@ def wes_analysis() -> PrismTestData:
             allow_empty=True,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/clonality/run_1/run_1_pyclone.tsv",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_pyclone.tsv",
+            local_path="gs://results/analysis/clonality/run_1/run_1_pyclone6.input.tsv",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_input.tsv",
             upload_placeholder="cdef9e1e-8e04-46ed-a9e6-bb618188a6d6",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/clonality/run_1/run_1_table.tsv",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_table.tsv",
+            local_path="gs://results/analysis/clonality/run_1/run_1_pyclone6.results.tsv",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_results.tsv",
             upload_placeholder="ctef9e1e-8e04-46ed-a9e6-bb618188a6d6",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_1/run_1_cnvcalls.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_cnvcalls.txt",
+            local_path="gs://results/analysis/clonality/run_1/run_1_pyclone6.results.summary.tsv",
+            upload_placeholder="dtef9e1e-8e04-46ed-a9e6-bb618188a6d6",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_summary.tsv",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_1/run_1.bin50.final.seqz.txt.gz",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_sequenza_final.txt.gz",
+            upload_placeholder="hb1a8d7a-fd96-4e75-b265-1590c703a301",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_1/run_1_CP_contours.pdf",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/cp_contours.pdf",
+            upload_placeholder="b86ab142-a925-433c-bb13-030c0684365e",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_1/run_1_alternative_solutions.txt",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/alternative_solutions.txt",
+            upload_placeholder="c86ab142-a925-433c-bb13-030c0684365e",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_1/run_1_chromosome_view.pdf",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_chromosome_view.pdf",
+            upload_placeholder="fb1a8d7a-fd96-4e75-b265-1590c703a301",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_1/run_1_sequenza_gainLoss.bed",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_sequenza_gainloss.bed",
+            upload_placeholder="gb1a8d7a-fd96-4e75-b265-1590c703a301",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_1/run_1.call.cns",
+            upload_placeholder="etef9e1e-8e04-46ed-a9e6-bb618188a6d6",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_cnv_segments.cns",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_1/run_1.call.enhanced.cns",
+            upload_placeholder="ftef9e1e-8e04-46ed-a9e6-bb618188a6d6",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_cnv_segments_enhanced.cns",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_1/run_1.scatter.png",
+            upload_placeholder="gtef9e1e-8e04-46ed-a9e6-bb618188a6d6",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_cnv_scatterplot.png",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_1/run_1_cnvkit_gainLoss.bed",
+            upload_placeholder="htef9e1e-8e04-46ed-a9e6-bb618188a6d6",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/clonality_cnvkit_gainloss.bed",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_1/run_1_segments.txt",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_segments.txt",
             upload_placeholder="85989077-49e4-44c6-8788-3b19357d3122",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_1/run_1_cnvcalls.txt.tn.tsv",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_cnvcalls.txt.tn.tsv",
+            local_path="gs://results/analysis/clonality/run_1/run_1_genome_view.pdf",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_genome_view.pdf",
             upload_placeholder="eb1a8d7a-fd96-4e75-b265-1590c703a301",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/msisensor2/run_1/run_1_msisensor.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/msisensor.txt",
-            upload_placeholder="msi18d7a-fd96-4e75-b265-1590c703a301",
+            local_path="gs://results/analysis/copynumber/run_1/run_1_consensus.bed",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_consensus.bed",
+            upload_placeholder="ib1a8d7a-fd96-4e75-b265-1590c703a301",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_1/run_1_tnscope.filter.vcf.gz",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/vcf_gz_tnscope_filter.vcf.gz",
-            upload_placeholder="b86ab142-a925-433c-bb13-030c0684365e",
+            local_path="gs://results/analysis/copynumber/run_1/run_1_consensus_merged_GAIN.bed",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_consensus_gain.bed",
+            upload_placeholder="jb1a8d7a-fd96-4e75-b265-1590c703a301",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/copynumber/run_1/run_1_consensus_merged_LOSS.bed",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_consensus_loss.bed",
+            upload_placeholder="kb1a8d7a-fd96-4e75-b265-1590c703a301",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/purity/run_1/run_1.cncf",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_facets.cncf",
+            upload_placeholder="lb1a8d7a-fd96-4e75-b265-1590c703a301",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/purity/run_1/run_1_facets_gainLoss.bed",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/copynumber_facets_gainloss.bed",
+            upload_placeholder="mb1a8d7a-fd96-4e75-b265-1590c703a301",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/msisensor2/run_1/run_1_msisensor2.txt",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/msisensor.txt",
+            upload_placeholder="msi18d7a-fd96-4e75-b265-1590c703a301",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -428,8 +608,8 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_1/run_1_tnscope.filter.maf",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/maf_tnscope_filter.maf",
+            local_path="gs://results/analysis/somatic/run_1/run_1_tnscope.output.maf",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/maf_tnscope_output.maf",
             upload_placeholder="53991cf3-b1b9-4b4a-830d-5eade9ef1321",
             metadata_availability=False,
             allow_empty=False,
@@ -463,8 +643,8 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/germline/run_1/run_1_vcfcompare.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/vcf_compare.txt",
+            local_path="gs://results/analysis/hlahd/CTTTPP111.00/result/CTTTPP111.00_final.result.txt",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/hla_final_result.txt",
             upload_placeholder="218be905-220d-417f-8395-0de84fcd81sg",
             metadata_availability=False,
             allow_empty=False,
@@ -481,14 +661,14 @@ def wes_analysis() -> PrismTestData:
             gs_key="test_prism_trial_id/wes/run_1/analysis/haplotyper.vcf.gz",
             upload_placeholder="e0b85ef8-47cb-45b9-bb94-c961150786b9",
             metadata_availability=False,
-            allow_empty=False,
+            allow_empty=True,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/rna/run_1/run_1_tnscope.filter.neoantigen.vep.rna.vcf",
+            local_path="gs://results/analysis/rna/run_1/run_1_tnscope.output.twist.neoantigen.vep.rna.vcf",
             gs_key="test_prism_trial_id/wes/run_1/analysis/vcf_tnscope_filter_neoantigen.vcf",
             upload_placeholder="d0b85ef8-47cb-45b9-bb94-c961150786b9",
             metadata_availability=False,
-            allow_empty=False,
+            allow_empty=True,
         ),
         LocalFileUploadEntry(
             local_path="gs://results/analysis/report/config.yaml",
@@ -533,13 +713,6 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/report/neoantigens/01_HLA_Results.tsv",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/HLA_results.tsv",
-            upload_placeholder="e47271fb-e2c7-5436-cafe-5cf84bc72bf6",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
             local_path="gs://results/analysis/neoantigen/run_1/combined/run_1.filtered.tsv",
             gs_key="test_prism_trial_id/wes/run_1/analysis/combined_filtered.tsv",
             upload_placeholder="f47271fb-e2c7-5436-cafe-5cf84bc72bf7",
@@ -561,22 +734,22 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_coverage_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/coverage_metrics.txt",
-            upload_placeholder="1ac21de4-6b15-48c0-9a0a-d66b9d99cd49",
+            local_path="gs://results/analysis/align/CTTTPP111.00/CTTTPP111.00_recalibrated.bam",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/recalibrated.bam",
+            upload_placeholder="dc4ce43e-bc4f-4a93-b482-454f874421a8",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_target_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/target_metrics.txt",
-            upload_placeholder="2bdcbe60-09d5-4f98-a1fc-01c374c147f5",
+            local_path="gs://results/analysis/align/CTTTPP111.00/CTTTPP111.00_recalibrated.bam.bai",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/recalibrated.bam.bai",
+            upload_placeholder="ec4ce43e-bc4f-4a93-b482-454f874421a8",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_coverage_metrics.sample_summary.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/coverage_metrics_summary.txt",
+            local_path="gs://results/analysis/tcellextrect/run_1/run_1_tcellextrect.txt",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/tcellextrect.txt",
             upload_placeholder="653bd098-3997-494b-8db9-03d114b3fbb3",
             metadata_availability=False,
             allow_empty=False,
@@ -585,6 +758,13 @@ def wes_analysis() -> PrismTestData:
             local_path="gs://results/analysis/germline/CTTTPP111.00/CTTTPP111.00_haplotyper.targets.vcf.gz",
             gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/haplotyper_targets.vcf.gz",
             upload_placeholder="ht899d73-7373-4041-85f9-6cc4324be811",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/germline/CTTTPP111.00/CTTTPP111.00_haplotyper.output.vcf",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/tumor/CTTTPP111.00/haplotyper_output.vcf",
+            upload_placeholder="it899d73-7373-4041-85f9-6cc4324be811",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -617,9 +797,30 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/purity/run_2/run_2.optimalpurityvalue.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/optimal_purity_value.txt",
+            local_path="gs://results/analysis/align/CTTTPP111.00/CTTTPP111.00_recalibrated.bam",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/recalibrated.bam",
+            upload_placeholder="d163f7aa-43ba-40f4-b11d-bddb79b41763",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/align/CTTTPP111.00/CTTTPP111.00_recalibrated.bam.bai",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/recalibrated.bam.bai",
+            upload_placeholder="ce406c27-2ef4-477c-93e5-684fbe4f9307",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_2/run_2_alternative_solutions.txt",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/alternative_solutions.txt",
             upload_placeholder="98621828-ee22-40d1-840a-0dae97e8bf09",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_2/run_2_CP_contours.pdf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/cp_contours.pdf",
+            upload_placeholder="08621828-ee22-40d1-840a-0dae97e8bf09",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -628,40 +829,33 @@ def wes_analysis() -> PrismTestData:
             gs_key="test_prism_trial_id/wes/run_2/analysis/haplotyper.vcf.gz",
             upload_placeholder="88621828-ee22-40d1-840a-0dae97e8bf09",
             metadata_availability=False,
-            allow_empty=False,
+            allow_empty=True,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/rna/run_2/run_2_tnscope.filter.neoantigen.vep.rna.vcf",
+            local_path="gs://results/analysis/rna/run_2/run_2_tnscope.output.twist.neoantigen.vep.rna.vcf",
             gs_key="test_prism_trial_id/wes/run_2/analysis/vcf_tnscope_filter_neoantigen.vcf",
             upload_placeholder="78621828-ee22-40d1-840a-0dae97e8bf09",
             metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_coverage_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/coverage_metrics.txt",
-            upload_placeholder="907d981b-7ca9-4bb9-a10f-ab4aa808c5a3",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_target_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/target_metrics.txt",
-            upload_placeholder="29b2cc56-422c-478c-8c6d-ee040ca1e6df",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_coverage_metrics.sample_summary.txt",
-            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/coverage_metrics_summary.txt",
-            upload_placeholder="3b5fded9-7274-45a4-a71e-48cf590814a9",
-            metadata_availability=False,
-            allow_empty=False,
+            allow_empty=True,
         ),
         LocalFileUploadEntry(
             local_path="gs://results/analysis/germline/CTTTPP111.00/CTTTPP111.00_haplotyper.targets.vcf.gz",
             gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/haplotyper_targets.vcf.gz",
             upload_placeholder="ht899d73-7373-4041-85f9-6cc4324be812",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/germline/CTTTPP111.00/CTTTPP111.00_haplotyper.output.vcf",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/haplotyper_output.vcf",
+            upload_placeholder="it899d73-7373-4041-85f9-6cc4324be812",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/hlahd/CTTTPP111.00/result/CTTTPP111.00_final.result.txt",
+            gs_key="test_prism_trial_id/wes/run_1/analysis/normal/CTTTPP111.00/hla_final_result.txt",
+            upload_placeholder="7b36da9d-c015-42be-80df-d22c17a29124",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -687,43 +881,134 @@ def wes_analysis() -> PrismTestData:
             allow_empty=True,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/clonality/run_2/run_2_pyclone.tsv",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_pyclone.tsv",
+            local_path="gs://results/analysis/clonality/run_2/run_2_pyclone6.input.tsv",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_input.tsv",
             upload_placeholder="a4cba177-0be5-4d7d-b635-4a60adaa9575",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/clonality/run_2/run_2_table.tsv",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_table.tsv",
+            local_path="gs://results/analysis/clonality/run_2/run_2_pyclone6.results.tsv",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_results.tsv",
             upload_placeholder="aucba177-0be5-4d7d-b635-4a60adaa9575",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_2/run_2_cnvcalls.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_cnvcalls.txt",
+            local_path="gs://results/analysis/clonality/run_2/run_2_pyclone6.results.summary.tsv",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_summary.tsv",
+            upload_placeholder="b4cba177-0be5-4d7d-b635-4a60adaa9575",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_2/run_2.call.cns",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_cnv_segments.cns",
+            upload_placeholder="bucba177-0be5-4d7d-b635-4a60adaa9575",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_2/run_2.call.enhanced.cns",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_cnv_segments_enhanced.cns",
+            upload_placeholder="c4cba177-0be5-4d7d-b635-4a60adaa9575",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_2/run_2.scatter.png",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_cnv_scatterplot.png",
+            upload_placeholder="cucba177-0be5-4d7d-b635-4a60adaa9575",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/cnvkit/run_2/run_2_cnvkit_gainLoss.bed",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/clonality_cnvkit_gainloss.bed",
+            upload_placeholder="d4cba177-0be5-4d7d-b635-4a60adaa9575",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_2/run_2_segments.txt",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_segments.txt",
             upload_placeholder="c187bcfe-b454-46a5-bf85-e2a2d5f7a9a5",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_2/run_2_cnvcalls.txt.tn.tsv",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_cnvcalls.txt.tn.tsv",
+            local_path="gs://results/analysis/clonality/run_2/run_2_genome_view.pdf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_genome_view.pdf",
             upload_placeholder="ba2984c0-f7e6-470c-95ef-e4b33cbdea48",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/msisensor2/run_2/run_2_msisensor.txt",
+            local_path="gs://results/analysis/clonality/run_2/run_2_chromosome_view.pdf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_chromosome_view.pdf",
+            upload_placeholder="d187bcfe-b454-46a5-bf85-e2a2d5f7a9a5",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_2/run_2_sequenza_gainLoss.bed",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_sequenza_gainloss.bed",
+            upload_placeholder="ca2984c0-f7e6-470c-95ef-e4b33cbdea48",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/clonality/run_2/run_2.bin50.final.seqz.txt.gz",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_sequenza_final.txt.gz",
+            upload_placeholder="e187bcfe-b454-46a5-bf85-e2a2d5f7a9a5",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/copynumber/run_2/run_2_consensus.bed",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_consensus.bed",
+            upload_placeholder="f187bcfe-b454-46a5-bf85-e2a2d5f7a9a5",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/copynumber/run_2/run_2_consensus_merged_GAIN.bed",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_consensus_gain.bed",
+            upload_placeholder="da2984c0-f7e6-470c-95ef-e4b33cbdea48",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/copynumber/run_2/run_2_consensus_merged_LOSS.bed",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_consensus_loss.bed",
+            upload_placeholder="g187bcfe-b454-46a5-bf85-e2a2d5f7a9a5",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/purity/run_2/run_2.cncf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_facets.cncf",
+            upload_placeholder="ea2984c0-f7e6-470c-95ef-e4b33cbdea48",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/purity/run_2/run_2_facets_gainLoss.bed",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/copynumber_facets_gainloss.bed",
+            upload_placeholder="h187bcfe-b454-46a5-bf85-e2a2d5f7a9a5",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/msisensor2/run_2/run_2_msisensor2.txt",
             gs_key="test_prism_trial_id/wes/run_2/analysis/msisensor.txt",
             upload_placeholder="msi28d7a-fd96-4e75-b265-1590c703a301",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.filter.vcf.gz",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/vcf_gz_tnscope_filter.vcf.gz",
+            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.output.twist.vcf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/tnscope_output_twist.vcf",
             upload_placeholder="64466c04-86f8-44af-953d-0cfb10d11b34",
             metadata_availability=False,
             allow_empty=False,
@@ -736,16 +1021,16 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.filter.maf",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/maf_tnscope_filter.maf",
-            upload_placeholder="1d589bba-708c-449f-879f-44cba199c635",
+            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.output.maf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/maf_tnscope_output.maf",
+            upload_placeholder="94466c04-86f8-44af-953d-0cfb10d11b36",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.output.twist.vcf",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/tnscope_output_twist.vcf",
-            upload_placeholder="99466c04-86f8-44af-953d-0cfb10d11b99",
+            local_path="gs://results/analysis/tcellextrect/run_2/run_2_tcellextrect.txt",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/tcellextrect.txt",
+            upload_placeholder="1d589bba-708c-449f-879f-44cba199c635",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -771,8 +1056,8 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/germline/run_2/run_2_vcfcompare.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/vcf_compare.txt",
+            local_path="gs://results/analysis/hlahd/CTTTPP121.00/result/CTTTPP121.00_final.result.txt",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/hla_final_result.txt",
             upload_placeholder="84f6bd4c-00db-4ce3-a6b6-a8482a3332sg",
             metadata_availability=False,
             allow_empty=False,
@@ -820,8 +1105,8 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/report/neoantigens/01_HLA_Results.tsv",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/HLA_results.tsv",
+            local_path="gs://results/analysis/purity/run_2/run_2.optimalpurityvalue.txt",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/optimal_purity_value.txt",
             upload_placeholder="76824763-fb9f-58b4-c7c4-8175759933f6",
             metadata_availability=False,
             allow_empty=False,
@@ -848,23 +1133,23 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_coverage_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/coverage_metrics.txt",
-            upload_placeholder="bc055607-9085-4f47-91e5-8f412c4dfafd",
+            local_path="gs://results/analysis/align/CTTTPP121.00/CTTTPP121.00_recalibrated.bam",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/recalibrated.bam",
+            upload_placeholder="e23d0858-eabb-4e9d-ad42-9bb4edadfd59",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_target_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/target_metrics.txt",
-            upload_placeholder="95e70b6a-1ddc-4bfe-84eb-6c4a6f1ee35d",
+            local_path="gs://results/analysis/align/CTTTPP121.00/CTTTPP121.00_recalibrated.bam.bai",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/recalibrated.bam.bai",
+            upload_placeholder="fa9a388b-d679-4a77-845f-2c4073425128",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_coverage_metrics.sample_summary.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/coverage_metrics_summary.txt",
-            upload_placeholder="3db263fd-2b23-4905-8389-dc8c49c01c2f",
+            local_path="gs://results/analysis/germline/CTTTPP121.00/CTTTPP121.00_haplotyper.output.vcf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/tumor/CTTTPP121.00/haplotyper_output.vcf",
+            upload_placeholder="it899d73-7373-4041-85f9-6cc4324be813",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -904,23 +1189,16 @@ def wes_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_coverage_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/coverage_metrics.txt",
-            upload_placeholder="5566abb7-6bfb-4a0f-94a3-f3b02979a131",
+            local_path="gs://results/analysis/align/CTTTPP121.00/CTTTPP121.00_recalibrated.bam",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/recalibrated.bam",
+            upload_placeholder="g2b13d18-36a2-4273-a69c-a143415231db",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_target_metrics.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/target_metrics.txt",
-            upload_placeholder="d92c402a-d9a5-4e6c-998d-b56b1b0b7ffa",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_coverage_metrics.sample_summary.txt",
-            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/coverage_metrics_summary.txt",
-            upload_placeholder="de83d3c9-6b0d-4317-b01e-dd28183744f7",
+            local_path="gs://results/analysis/align/CTTTPP121.00/CTTTPP121.00_recalibrated.bam.bai",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/recalibrated.bam.bai",
+            upload_placeholder="5a06b799-2eb8-47f3-92fa-f5e21da85697",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -928,6 +1206,20 @@ def wes_analysis() -> PrismTestData:
             local_path="gs://results/analysis/germline/CTTTPP121.00/CTTTPP121.00_haplotyper.targets.vcf.gz",
             gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/haplotyper_targets.vcf.gz",
             upload_placeholder="ht899d73-7373-4041-85f9-6cc4324be814",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/germline/CTTTPP121.00/CTTTPP121.00_haplotyper.output.vcf",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/haplotyper_output.vcf",
+            upload_placeholder="it899d73-7373-4041-85f9-6cc4324be814",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/hlahd/CTTTPP121.00/result/CTTTPP121.00_final.result.txt",
+            gs_key="test_prism_trial_id/wes/run_2/analysis/normal/CTTTPP121.00/hla_final_result.txt",
+            upload_placeholder="0371d710-e3d0-4d1b-b87f-23bbadc4ae7e",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -987,43 +1279,29 @@ def wes_tumor_only_analysis() -> PrismTestData:
                                 "upload_placeholder": "msi18d7a-fd96-4e75-b265-1590c703a301"
                             }
                         },
-                        "copynumber": {
-                            "copynumber_cnv_calls": {
-                                "upload_placeholder": "85989077-49e4-44c6-8788-3b19357d3122"
-                            },
-                            "copynumber_cnv_calls_tsv": {
-                                "upload_placeholder": "eb1a8d7a-fd96-4e75-b265-1590c703a301"
-                            },
-                        },
                         "neoantigen": {
-                            "HLA_results": {
-                                "upload_placeholder": "e47271fb-e2c7-5436-cafe-5cf84bc72bf6"
-                            },
                             "combined_filtered": {
                                 "upload_placeholder": "f47271fb-e2c7-5436-cafe-5cf84bc72bf7"
                             },
                         },
                         "somatic": {
-                            "vcf_gz_tnscope_filter": {
-                                "upload_placeholder": "b86ab143-a925-433c-bb13-030c0684365e"
-                            },
                             "vcf_gz_tnscope_output": {
                                 "upload_placeholder": "c86ab142-b925-433c-bb13-030c0684365f"
                             },
-                            "maf_tnscope_filter": {
-                                "upload_placeholder": "54991cf3-b1b9-4b4a-830d-4eade9ef1321"
+                            "maf_tnscope_output": {
+                                "upload_placeholder": "d86ab142-b925-433c-bb13-030c0684365f"
                             },
                             "tnscope_output_twist_vcf": {
                                 "upload_placeholder": "64466c04-86f8-44af-953d-0cfb10d11b99"
+                            },
+                            "tnscope_output_twist_maf": {
+                                "upload_placeholder": "1d589bba-708c-449f-879f-44cba199c666"
                             },
                             "tnscope_output_twist_filtered_vcf": {
                                 "upload_placeholder": "84466c04-86f8-44af-953d-0cfb10d11b88"
                             },
                             "tnscope_output_twist_filtered_maf": {
                                 "upload_placeholder": "e73b8502-d7cc-4002-a96d-57e635f4f277"
-                            },
-                            "tnscope_output_twist_maf": {
-                                "upload_placeholder": "1d589bba-708c-449f-879f-44cba199c666"
                             },
                         },
                         "rna": {
@@ -1034,18 +1312,12 @@ def wes_tumor_only_analysis() -> PrismTestData:
                                 "upload_placeholder": "d0b85ef8-47cb-45b9-bb94-c961150786b9"
                             },
                         },
+                        "tcell": {
+                            "tcellextrect": {
+                                "upload_placeholder": "e47271fb-e2c7-5436-cafe-5cf84bc72bf6"
+                            }
+                        },
                         "tumor": {
-                            "metrics": {
-                                "coverage_metrics": {
-                                    "upload_placeholder": "1ac21de4-6b15-48c0-9a0a-d66b9d99cd49"
-                                },
-                                "target_metrics": {
-                                    "upload_placeholder": "2bdcbe60-09d5-4f98-a1fc-01c374c147f5"
-                                },
-                                "coverage_metrics_summary": {
-                                    "upload_placeholder": "653bd098-3997-494b-8db9-03d114b3fbb3"
-                                },
-                            },
                             "cimac_id": "CTTTPP111.00",
                             "alignment": {
                                 "align_sorted_dedup": {
@@ -1054,8 +1326,17 @@ def wes_tumor_only_analysis() -> PrismTestData:
                                 "align_sorted_dedup_index": {
                                     "upload_placeholder": "cc4ce43e-bc4f-4a93-b482-454f874421a8"
                                 },
+                                "align_recalibrated": {
+                                    "upload_placeholder": "b86ab143-a925-433c-bb13-030c0684365e"
+                                },
+                                "align_recalibrated_index": {
+                                    "upload_placeholder": "54991cf3-b1b9-4b4a-830d-4eade9ef1321"
+                                },
                             },
-                            "optitype": {
+                            "hla": {
+                                "hla_final_result": {
+                                    "upload_placeholder": "85989077-49e4-44c6-8788-3b19357d3122"
+                                },
                                 "optitype_result": {
                                     "upload_placeholder": "a5899d73-7373-4041-85f9-6cc4324be817"
                                 },
@@ -1092,34 +1373,23 @@ def wes_tumor_only_analysis() -> PrismTestData:
                                 "upload_placeholder": "msi28d7a-fd96-4e75-b265-1590c703a301"
                             }
                         },
-                        "copynumber": {
-                            "copynumber_cnv_calls": {
-                                "upload_placeholder": "c187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
-                            },
-                            "copynumber_cnv_calls_tsv": {
-                                "upload_placeholder": "ba2984c0-f7e6-470c-95ef-e4b33cbdea48"
-                            },
-                        },
                         "neoantigen": {
-                            "HLA_results": {
-                                "upload_placeholder": "76824763-fb9f-58b4-c7c4-8175759933f6"
-                            },
                             "combined_filtered": {
                                 "upload_placeholder": "86824763-fb9f-58b4-c7c4-8175759933f7"
                             },
                         },
                         "somatic": {
-                            "vcf_gz_tnscope_filter": {
-                                "upload_placeholder": "64566c04-86f8-44af-953d-0cfb10d11b34"
-                            },
                             "vcf_gz_tnscope_output": {
                                 "upload_placeholder": "84466c04-86f8-44af-953d-1cfb10d11b36"
                             },
-                            "maf_tnscope_filter": {
+                            "maf_tnscope_output": {
                                 "upload_placeholder": "1d689bba-708c-449f-879f-44cba199c635"
                             },
                             "tnscope_output_twist_vcf": {
                                 "upload_placeholder": "64466c04-86f8-44af-953d-0cfb10d11999"
+                            },
+                            "tnscope_output_twist_maf": {
+                                "upload_placeholder": "1d589bba-708c-449f-879f-44cba1996666"
                             },
                             "tnscope_output_twist_filtered_vcf": {
                                 "upload_placeholder": "84466c04-86f8-44af-953d-0cfb10d11888"
@@ -1127,22 +1397,13 @@ def wes_tumor_only_analysis() -> PrismTestData:
                             "tnscope_output_twist_filtered_maf": {
                                 "upload_placeholder": "e73b8502-d7cc-4002-a96d-57e635f4f777"
                             },
-                            "tnscope_output_twist_maf": {
-                                "upload_placeholder": "1d589bba-708c-449f-879f-44cba1996666"
+                        },
+                        "tcell": {
+                            "tcellextrect": {
+                                "upload_placeholder": "64566c04-86f8-44af-953d-0cfb10d11b34"
                             },
                         },
                         "tumor": {
-                            "metrics": {
-                                "coverage_metrics": {
-                                    "upload_placeholder": "bc055607-9085-4f47-91e5-8f412c4dfafd"
-                                },
-                                "target_metrics": {
-                                    "upload_placeholder": "95e70b6a-1ddc-4bfe-84eb-6c4a6f1ee35d"
-                                },
-                                "coverage_metrics_summary": {
-                                    "upload_placeholder": "3db263fd-2b23-4905-8389-dc8c49c01c2f"
-                                },
-                            },
                             "cimac_id": "CTTTPP121.00",
                             "alignment": {
                                 "align_sorted_dedup": {
@@ -1151,8 +1412,17 @@ def wes_tumor_only_analysis() -> PrismTestData:
                                 "align_sorted_dedup_index": {
                                     "upload_placeholder": "ea9a388b-d679-4a77-845f-2c4073425128"
                                 },
+                                "align_recalibrated": {
+                                    "upload_placeholder": "c187bcfe-b454-46a5-bf85-e2a2d5f7a9a5"
+                                },
+                                "align_recalibrated_index": {
+                                    "upload_placeholder": "ba2984c0-f7e6-470c-95ef-e4b33cbdea48"
+                                },
                             },
-                            "optitype": {
+                            "hla": {
+                                "hla_final_result": {
+                                    "upload_placeholder": "76824763-fb9f-58b4-c7c4-8175759933f6"
+                                },
                                 "optitype_result": {
                                     "upload_placeholder": "671d710e-f245-4d2b-8732-2774e26aec10"
                                 },
@@ -1205,23 +1475,16 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/rna/run_1/run_1_tnscope.filter.neoantigen.vep.rna.vcf",
+            local_path="gs://results/analysis/rna/run_1/run_1_tnscope.output.twist.neoantigen.vep.rna.vcf",
             gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/vcf_tnscope_filter_neoantigen.vcf",
             upload_placeholder="d0b85ef8-47cb-45b9-bb94-c961150786b9",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_1/run_1_cnvcalls.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/copynumber_cnvcalls.txt",
+            local_path="gs://results/analysis/hlahd/CTTTPP111.00/result/CTTTPP111.00_final.result.txt",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tumor/CTTTPP111.00/hla_final_result.txt",
             upload_placeholder="85989077-49e4-44c6-8788-3b19357d3122",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_1/run_1_cnvcalls.txt.tn.tsv",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/copynumber_cnvcalls.txt.tn.tsv",
-            upload_placeholder="eb1a8d7a-fd96-4e75-b265-1590c703a301",
             metadata_availability=False,
             allow_empty=False,
         ),
@@ -1233,15 +1496,15 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=True,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/msisensor2/run_1/run_1_msisensor.txt",
+            local_path="gs://results/analysis/msisensor2/run_1/run_1_msisensor2.txt",
             gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/msisensor.txt",
             upload_placeholder="msi18d7a-fd96-4e75-b265-1590c703a301",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_1/run_1_tnscope.filter.vcf.gz",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/vcf_gz_tnscope_filter.vcf.gz",
+            local_path="gs://results/analysis/align/CTTTPP111.00/CTTTPP111.00_recalibrated.bam",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tumor/CTTTPP111.00/recalibrated.bam",
             upload_placeholder="b86ab143-a925-433c-bb13-030c0684365e",
             metadata_availability=False,
             allow_empty=False,
@@ -1254,8 +1517,15 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_1/run_1_tnscope.filter.maf",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/maf_tnscope_filter.maf",
+            local_path="gs://results/analysis/somatic/run_1/run_1_tnscope.output.maf",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/maf_tnscope_output.maf",
+            upload_placeholder="d86ab142-b925-433c-bb13-030c0684365f",
+            metadata_availability=False,
+            allow_empty=False,
+        ),
+        LocalFileUploadEntry(
+            local_path="gs://results/analysis/align/CTTTPP111.00/CTTTPP111.00_recalibrated.bam.bai",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tumor/CTTTPP111.00/recalibrated.bam.bai",
             upload_placeholder="54991cf3-b1b9-4b4a-830d-4eade9ef1321",
             metadata_availability=False,
             allow_empty=False,
@@ -1324,8 +1594,8 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/report/neoantigens/01_HLA_Results.tsv",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/HLA_results.tsv",
+            local_path="gs://results/analysis/tcellextrect/run_1/run_1_tcellextrect.txt",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tcellextrect.txt",
             upload_placeholder="e47271fb-e2c7-5436-cafe-5cf84bc72bf6",
             metadata_availability=False,
             allow_empty=False,
@@ -1352,27 +1622,6 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_coverage_metrics.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tumor/CTTTPP111.00/coverage_metrics.txt",
-            upload_placeholder="1ac21de4-6b15-48c0-9a0a-d66b9d99cd49",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_target_metrics.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tumor/CTTTPP111.00/target_metrics.txt",
-            upload_placeholder="2bdcbe60-09d5-4f98-a1fc-01c374c147f5",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP111.00/CTTTPP111.00_coverage_metrics.sample_summary.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tumor/CTTTPP111.00/coverage_metrics_summary.txt",
-            upload_placeholder="653bd098-3997-494b-8db9-03d114b3fbb3",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
             local_path="gs://results/analysis/optitype/CTTTPP111.00/CTTTPP111.00_result.tsv",
             gs_key="test_prism_trial_id/wes_tumor_only/run_1/analysis/tumor/CTTTPP111.00/optitype_result.tsv",
             upload_placeholder="a5899d73-7373-4041-85f9-6cc4324be817",
@@ -1394,22 +1643,22 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/rna/run_2/run_2_tnscope.filter.neoantigen.vep.rna.vcf",
+            local_path="gs://results/analysis/rna/run_2/run_2_tnscope.output.twist.neoantigen.vep.rna.vcf",
             gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/vcf_tnscope_filter_neoantigen.vcf",
             upload_placeholder="78621828-ee22-40d1-840a-0dae97e8bf09",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_2/run_2_cnvcalls.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/copynumber_cnvcalls.txt",
+            local_path="gs://results/analysis/align/CTTTPP121.00/CTTTPP121.00_recalibrated.bam",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tumor/CTTTPP121.00/recalibrated.bam",
             upload_placeholder="c187bcfe-b454-46a5-bf85-e2a2d5f7a9a5",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/copynumber/run_2/run_2_cnvcalls.txt.tn.tsv",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/copynumber_cnvcalls.txt.tn.tsv",
+            local_path="gs://results/analysis/align/CTTTPP121.00/CTTTPP121.00_recalibrated.bam.bai",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tumor/CTTTPP121.00/recalibrated.bam.bai",
             upload_placeholder="ba2984c0-f7e6-470c-95ef-e4b33cbdea48",
             metadata_availability=False,
             allow_empty=False,
@@ -1422,15 +1671,15 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=True,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/msisensor2/run_2/run_2_msisensor.txt",
+            local_path="gs://results/analysis/msisensor2/run_2/run_2_msisensor2.txt",
             gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/msisensor.txt",
             upload_placeholder="msi28d7a-fd96-4e75-b265-1590c703a301",
             metadata_availability=False,
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.filter.vcf.gz",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/vcf_gz_tnscope_filter.vcf.gz",
+            local_path="gs://results/analysis/tcellextrect/run_2/run_2_tcellextrect.txt",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tcellextrect.txt",
             upload_placeholder="64566c04-86f8-44af-953d-0cfb10d11b34",
             metadata_availability=False,
             allow_empty=False,
@@ -1443,8 +1692,8 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.filter.maf",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/maf_tnscope_filter.maf",
+            local_path="gs://results/analysis/somatic/run_2/run_2_tnscope.output.maf",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/maf_tnscope_output.maf",
             upload_placeholder="1d689bba-708c-449f-879f-44cba199c635",
             metadata_availability=False,
             allow_empty=False,
@@ -1513,8 +1762,8 @@ def wes_tumor_only_analysis() -> PrismTestData:
             allow_empty=False,
         ),
         LocalFileUploadEntry(
-            local_path="gs://results/analysis/report/neoantigens/01_HLA_Results.tsv",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/HLA_results.tsv",
+            local_path="gs://results/analysis/hlahd/CTTTPP121.00/result/CTTTPP121.00_final.result.txt",
+            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tumor/CTTTPP121.00/hla_final_result.txt",
             upload_placeholder="76824763-fb9f-58b4-c7c4-8175759933f6",
             metadata_availability=False,
             allow_empty=False,
@@ -1537,27 +1786,6 @@ def wes_tumor_only_analysis() -> PrismTestData:
             local_path="gs://results/analysis/align/CTTTPP121.00/CTTTPP121.00.sorted.dedup.bam.bai",
             gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tumor/CTTTPP121.00/sorted.dedup.bam.bai",
             upload_placeholder="ea9a388b-d679-4a77-845f-2c4073425128",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_coverage_metrics.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tumor/CTTTPP121.00/coverage_metrics.txt",
-            upload_placeholder="bc055607-9085-4f47-91e5-8f412c4dfafd",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_target_metrics.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tumor/CTTTPP121.00/target_metrics.txt",
-            upload_placeholder="95e70b6a-1ddc-4bfe-84eb-6c4a6f1ee35d",
-            metadata_availability=False,
-            allow_empty=False,
-        ),
-        LocalFileUploadEntry(
-            local_path="gs://results/analysis/metrics/CTTTPP121.00/CTTTPP121.00_coverage_metrics.sample_summary.txt",
-            gs_key="test_prism_trial_id/wes_tumor_only/run_2/analysis/tumor/CTTTPP121.00/coverage_metrics_summary.txt",
-            upload_placeholder="3db263fd-2b23-4905-8389-dc8c49c01c2f",
             metadata_availability=False,
             allow_empty=False,
         ),

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import pytest
 
 from cidc_schemas.migrations import (
@@ -352,9 +353,8 @@ def test_v0_25_41_to_v0_25_42():
         }
     }
 
-    result: MigrationResult = v0_25_41_to_v0_25_42.upgrade(ct)
+    result: MigrationResult = v0_25_41_to_v0_25_42.upgrade(deepcopy(ct))
     assert result.result == target_ct
     assert result.file_updates == {}
 
-    # downgrade is a noop for this migration
     assert v0_25_41_to_v0_25_42.downgrade(target_ct).result == ct

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -4,12 +4,14 @@ from cidc_schemas.migrations import (
     _follow_path,
     v0_10_0_to_v0_10_2,
     MigrationError,
+    MigrationResult,
     v0_10_2_to_v0_11_0,
     v0_15_2_to_v0_15_3,
     v0_21_1_to_v0_22_0,
     _ENCRYPTED_FIELD_LEN,
     v0_23_0_to_v0_23_1,
     v0_23_18_to_v0_24_0,
+    v0_25_41_to_v0_25_042,
 )
 
 
@@ -174,7 +176,7 @@ def test_v0_10_0_to_v0_10_2():
         }
     }
 
-    res = v0_10_0_to_v0_10_2.upgrade(old_ct)
+    res: MigrationResult = v0_10_0_to_v0_10_2.upgrade(old_ct)
 
     # Extract artifacts from migration result
     get_artifact_path = lambda record_idx: _follow_path(
@@ -313,7 +315,7 @@ def test_v0_23_18_to_v0_24_0():
         }
     }
 
-    result = v0_23_18_to_v0_24_0.upgrade(ct)
+    result: MigrationResult = v0_23_18_to_v0_24_0.upgrade(ct)
     assert result.result == target_ct
     assert result.file_updates == {
         "test-trial/chip_1234/assay_npx.xlsx": {
@@ -328,3 +330,31 @@ def test_v0_23_18_to_v0_24_0():
 
     # downgrade is a noop for this migration
     assert v0_23_18_to_v0_24_0.downgrade(target_ct).result == target_ct
+
+
+def test_v0_25_41_to_v0_25_042():
+    # Unrelated data is unchanged
+    assert v0_25_41_to_v0_25_042.downgrade(
+        v0_25_41_to_v0_25_042.upgrade({"foo": "bar"}).result
+    ).result == {"foo": "bar"}
+
+    ct = {
+        "analyses": {
+            "wes_analysis": {"foo": "bar"},
+            "wes_tumor_only_analysis": {"biz": "baz"},
+        }
+    }
+
+    target_ct = {
+        "analyses": {
+            "wes_analysis_old": {"foo": "bar"},
+            "wes_tumor_only_analysis_old": {"biz": "baz"},
+        }
+    }
+
+    result: MigrationResult = v0_25_41_to_v0_25_042.upgrade(ct)
+    assert result.result == target_ct
+    assert result.file_updates == {}
+
+    # downgrade is a noop for this migration
+    assert v0_25_41_to_v0_25_042.downgrade(target_ct).result == ct

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -11,7 +11,7 @@ from cidc_schemas.migrations import (
     _ENCRYPTED_FIELD_LEN,
     v0_23_0_to_v0_23_1,
     v0_23_18_to_v0_24_0,
-    v0_25_41_to_v0_25_042,
+    v0_25_41_to_v0_25_42,
 )
 
 
@@ -332,10 +332,10 @@ def test_v0_23_18_to_v0_24_0():
     assert v0_23_18_to_v0_24_0.downgrade(target_ct).result == target_ct
 
 
-def test_v0_25_41_to_v0_25_042():
+def test_v0_25_41_to_v0_25_42():
     # Unrelated data is unchanged
-    assert v0_25_41_to_v0_25_042.downgrade(
-        v0_25_41_to_v0_25_042.upgrade({"foo": "bar"}).result
+    assert v0_25_41_to_v0_25_42.downgrade(
+        v0_25_41_to_v0_25_42.upgrade({"foo": "bar"}).result
     ).result == {"foo": "bar"}
 
     ct = {
@@ -352,9 +352,9 @@ def test_v0_25_41_to_v0_25_042():
         }
     }
 
-    result: MigrationResult = v0_25_41_to_v0_25_042.upgrade(ct)
+    result: MigrationResult = v0_25_41_to_v0_25_42.upgrade(ct)
     assert result.result == target_ct
     assert result.file_updates == {}
 
     # downgrade is a noop for this migration
-    assert v0_25_41_to_v0_25_042.downgrade(target_ct).result == ct
+    assert v0_25_41_to_v0_25_42.downgrade(target_ct).result == ct


### PR DESCRIPTION
Parallels
- https://github.com/CIMAC-CIDC/cidc-ngs-pipeline-api/pull/55

## What

For Len's WES v3 PR to NSG API, apply changes to WES analysis and WES-TO schemas.
Maintains a place for the existing data under the new `wes_analysis_old` and `wes_tumor_only_analysis_old` while putting the new ones into the original spot.
Templates were modified to only load v3 analyses going forward.

## Why
WES v3.0 - Integrate changes into schemas
- [CIDC-1386](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1386)
- [CIDC-1396](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1396)

## How

- Locally installed NGS pipeline in advance of merge, fixed all tests
- Used `oneOf` for changed values in `required`
  - specified a variant with `not` for newly added requirements
- removed values from `required` when they are no longer produced and maintained only for compatibility
- Updated `template.py::generate_all_template_schemas` and dependencies for additionally complexities
- Updated test upload data to match new expected structure

## Remarks

- Did NOT modify clinical trial examples in tests, therefore ensuring backwards compatibility to the version(s) of WES analysis in `tests\data\clinicaltrial_examples\CT_1PA_multiWES.json` which is not v3
  - this will need to be updated if full compatibility will be removed, though this is unlikely given published 10021

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
