### PR TITLE
CIDC-1393 Add automatic generation of WES analysis upload templates to email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.42` - 7 Jul 2022
+
+- `added` automatic generate of WES analysis upload templates to email
+
 ## Version `0.25.41` - 17 Jun 2022
 
 - `added` 'Agilent SS Human All Exon V4' bait set option for wes assay

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.41"
+__version__ = "0.25.42"

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.42"
+__version__ = "0.25.43"

--- a/cidc_schemas/prism/pipelines.py
+++ b/cidc_schemas/prism/pipelines.py
@@ -177,7 +177,6 @@ class _Wes_pipeline_config:
             elif run.tumor_cimac_id in all_wes_records:
                 workbook = wes_tumor_only_analysis_template.to_excel(tmp, close=False)
                 worksheet = workbook.get_worksheet_by_name("WES tumor-only Analysis")
-                print("sheets:", [sht.get_name() for sht in workbook.worksheets()])
 
                 worksheet.write(2, 2, BIOFX_WES_ANALYSIS_FOLDER)
                 worksheet.write(6, 1, run_id)

--- a/cidc_schemas/prism/pipelines.py
+++ b/cidc_schemas/prism/pipelines.py
@@ -3,14 +3,28 @@ import csv
 import io
 
 import logging
-from typing import Dict, List, NamedTuple
+from tempfile import NamedTemporaryFile
+from typing import Dict, List, NamedTuple, Tuple, Union
 from datetime import datetime
 from collections import defaultdict
+
+import openpyxl
+
+from cidc_schemas.template import Template
 
 from ..util import load_pipeline_config_template, participant_id_from_cimac
 from .constants import PROTOCOL_ID_FIELD_NAME
 
+BIOFX_WES_ANALYSIS_FOLDER: str = "/mnt/ssd/wes/analysis"
 logger = logging.getLogger(__file__)
+
+
+class _AnalysisRun(NamedTuple):
+    """container class for possible runs to report"""
+
+    tumor_cimac_id: str
+    normal_cimac_id: str = None
+    run_id: str = None
 
 
 class _Wes_pipeline_config:
@@ -55,7 +69,7 @@ class _Wes_pipeline_config:
 
     def _choose_which_normal(self, full_ct: dict, cimac_ids: List[str]) -> str:
         """
-        Based on sequencing quality, choose which cimac_id to use
+        TODO Based on sequencing quality, choose which cimac_id to use
         Currently just returns the first of the list
         """
         return sorted(cimac_ids)[0]
@@ -129,23 +143,62 @@ class _Wes_pipeline_config:
             partic_dict["tumors"] = dict(partic_dict["tumors"])
         return dict(partic_map)
 
-    def __call__(self, full_ct: dict, patch: dict, bucket: str) -> Dict[str, str]:
+    def _generate_template_excel(
+        self,
+        run: _AnalysisRun,
+        all_wes_records: Dict[str, dict],
+        wes_analysis_template: Template,
+        wes_tumor_only_analysis_template: Template,
+    ) -> str:
         """
-        Generates a mapping from run_ids to the
-        generated snakemake wes .yaml configs.
-
-        Patch is expected to be already merged into full_ct.
+        Generates the Excel upload template for the given WES analysis run
         """
+        with NamedTemporaryFile() as tmp:
+            # use tumor CIMAC ID as run_id if not given
+            run_id = run.run_id if run.run_id else run.tumor_cimac_id
 
-        class AnalysisRun(NamedTuple):
-            """ontainer class for possible runs to report"""
+            # if we have data files for *both* items in a tumor/normal pair
+            if (
+                run.normal_cimac_id
+                and run.normal_cimac_id in all_wes_records
+                and run.tumor_cimac_id in all_wes_records
+            ):
+                wes_analysis_template.to_excel(tmp.name)
+                tmp.seek(0)
 
-            tumor_cimac_id: str
-            normal_cimac_id: str = None
-            run_id: str = None
+                workbook = openpyxl.Workbook(tmp.name)
+                print(workbook.sheetnames)
 
-        potential_new_runs: List[AnalysisRun] = []  # to be rendered
+                worksheet = workbook["WES Analysis"]
+                worksheet.write(2, 2, BIOFX_WES_ANALYSIS_FOLDER)
+                worksheet.write(6, 1, run_id)
+                worksheet.write(6, 2, run.normal_cimac_id)
+                worksheet.write(6, 3, run.tumor_cimac_id)
 
+                workbook.save()
+                workbook.close()
+
+            # if there's no matching normal or doesn't have the files,
+            # render it as a tumor_only sample if we have its data files
+            elif run.tumor_cimac_id in all_wes_records:
+                wes_tumor_only_analysis_template.to_excel(tmp)
+                tmp.seek(0)
+                workbook = openpyxl.Workbook(tmp)
+
+                worksheet = workbook["WES Analysis"]
+                worksheet.write(2, 2, BIOFX_WES_ANALYSIS_FOLDER)
+                worksheet.write(6, 1, run_id)
+                worksheet.write(6, 2, run.tumor_cimac_id)
+
+                workbook.save()
+                workbook.close()
+
+            tmp.seek(0)
+            ret: str = tmp.read().decode()
+        return ret
+
+    def _find_potential_runs(self, full_ct: dict, patch: dict) -> List[_AnalysisRun]:
+        potential_new_runs: List[_AnalysisRun] = []  # to be returned
         if self.upload_type == "assay":
             # first we search for cimac_ids for which we just got new data files
             new_data_ids = set()
@@ -169,41 +222,52 @@ class _Wes_pipeline_config:
                 runi = r["run_id"]
                 # we filter runs, for which we have new data for at least on of the samples:
                 if norm_i in new_data_ids or tum_i in new_data_ids:
-                    potential_new_runs.append(AnalysisRun(tum_i, norm_i, runi))
+                    potential_new_runs.append(_AnalysisRun(tum_i, norm_i, runi))
                     new_data_ids.difference([norm_i, tum_i])
 
             # the rest of the new IDs could be possible tumor_only runs
             for new_id in new_data_ids:
-                potential_new_runs.append(AnalysisRun(new_id))
+                potential_new_runs.append(_AnalysisRun(new_id))
 
         elif self.upload_type == "pairing":
             # first we filter cimac_ids for which we now got pairing info
             # from analysis runs.
             potential_new_runs = [
-                AnalysisRun(
+                _AnalysisRun(
                     r["tumor"]["cimac_id"], r["normal"]["cimac_id"], r["run_id"]
                 )
                 for r in patch["analysis"]["wes_analysis"]["pair_runs"]
             ]
 
-        # then we compose a list of all records from all assay runs,
-        # so we can filter out analysis runs for which we have data for both samples
-        all_wes_records = {}
-        for wes in full_ct["assays"]["wes"]:
-            for r in wes["records"]:
-                all_wes_records[r["cimac_id"]] = r
+        return potential_new_runs
 
-        # classify all of the WES records as tumor or normal and get collection event name
-        # in preparation for (semi)automated pairing
-        # partic_map = {
-        #     cimac_participant_id str: {
-        #         "tumors": {cimac_id str: collection_event_name str},
-        #         "normals": {cimac_id str: collection_event_name str},
-        #     }
-        # }
-        partic_map = self._generate_partic_map(full_ct, all_wes_records.keys())
+    def _pair_all_samples(
+        self, partic_map: Dict[str, Dict[str, Dict[str, str]]]
+    ) -> List[Tuple[str, str, str, str]]:
+        """
+        (Semi)automated pairing of tumor and normal samples
 
-        # (semi)automated pairing of tumor and normal samples
+        Parameters
+        ----------
+        partic_map: Dict[str, Dict[str, List[str]]]
+        {
+            cimac_participant_id str: {
+                "tumors":  {collection_event_name str: [cimac_id str, ...], ...},
+                "normals": {collection_event_name str: cimac_id str, ...},
+            },
+            ...
+        }
+            as returned by participant
+
+        Returns
+        -------
+            List[(
+                tumor_cimac_id: str, tumor_collection_event: str,
+                normal_cimac_id: str, normal_collection_event: str
+            )]
+                one entry for each pair, unmatched tumor, and unmatched normal
+                if not paired, values are empty ie ""
+        """
         tumor_pair_list = []
         for partic in partic_map:
             tumors = partic_map[partic]["tumors"]
@@ -253,43 +317,112 @@ class _Wes_pipeline_config:
                         ("", "", normals[collection_event], collection_event)
                     )
 
-        file_content: str = (
-            f"{PROTOCOL_ID_FIELD_NAME},{full_ct[PROTOCOL_ID_FIELD_NAME]}\n"
-        )
+        return tumor_pair_list
+
+    def _generate_run_config(
+        self, run: _AnalysisRun, all_wes_records: Dict[str, dict], bucket: str
+    ) -> str:
+        # if we have data files for *both* items in a tumor/normal pair
+        if (
+            run.normal_cimac_id
+            and run.normal_cimac_id in all_wes_records
+            and run.tumor_cimac_id in all_wes_records
+        ):
+            # then this is a run we need, and so we render it
+            return self.analysis_config.render(
+                **{
+                    "run_id": run.run_id,
+                    "tumor_sample": all_wes_records[run.tumor_cimac_id],
+                    "normal_sample": all_wes_records[run.normal_cimac_id],
+                    "BIOFX_BUCKET_NAME": bucket,
+                }
+            )
+
+        # if there's no matching normal or doesn't have the files,
+        # render it as a tumor_only sample if we have its data files
+        elif run.tumor_cimac_id in all_wes_records:
+            # use tumor CIMAC ID as run_id if not given (formatted in jinja)
+            run_id = run.run_id if run.run_id else run.tumor_cimac_id
+            return self.tumor_only_analysis_config.render(
+                **{
+                    "run_id": run_id,
+                    "tumor_sample": all_wes_records[run.tumor_cimac_id],
+                    "BIOFX_BUCKET_NAME": bucket,
+                }
+            )
+
+    def _generate_pairing_csv(
+        self, trial_id: str, tumor_pair_list: List[Tuple[str, str, str, str]]
+    ) -> str:
+        file_content: str = f"{PROTOCOL_ID_FIELD_NAME},{trial_id}\n"
         file_content += "tumor,tumor_collection_event,normal,normal_collection_event\n"
         file_content += "\n".join([",".join(entry) for entry in tumor_pair_list])
+        return file_content
 
-        res = {}
-        res[full_ct[PROTOCOL_ID_FIELD_NAME] + "_pairing.csv"] = file_content
+    def __call__(
+        self, full_ct: dict, patch: dict, bucket: str
+    ) -> Dict[str, str]:
+        """
+        Generates a mapping from filename to the files to attach.
+        For each run_id, there is:
+            a generated snakemake wes config f"{run_id}.yaml"
+            a generated template for analysis ingestion f"{run_id}.template.xlsx"
+
+        Patch is expected to be already merged into full_ct.
+        """
+        # find all the potential new runs to be rendered
+        potential_new_runs: List[_AnalysisRun] = self._find_potential_runs(
+            full_ct, patch
+        )
+
+        # then we compose a list of all records from all assay runs,
+        # so we can filter out analysis runs for which we have data for both samples
+        all_wes_records: Dict[str, dict] = dict()
+        for wes in full_ct["assays"]["wes"]:
+            for r in wes["records"]:
+                all_wes_records[r["cimac_id"]] = r
+
+        # classify all of the WES records as tumor or normal and get collection event name
+        # in preparation for (semi)automated pairing
+        # partic_map = {
+        #     cimac_participant_id str: {
+        #         "tumors": {cimac_id str: collection_event_name str},
+        #         "normals": {cimac_id str: collection_event_name str},
+        #     }
+        # }
+        partic_map = self._generate_partic_map(full_ct, all_wes_records.keys())
+
+        # (semi)automated pairing of tumor and normal samples
+        # as partic_map is generated using only the WES samples,
+        # it's the same as pairing all samples
+        tumor_pair_list = self._pair_all_samples(partic_map)
+
+        # Begin preparing response
+        # {filename: contents}
+        res: Dict[str, str] = {
+            # add a pairing sheet for new runs
+            full_ct[PROTOCOL_ID_FIELD_NAME]
+            + "_pairing.csv": self._generate_pairing_csv(
+                full_ct[PROTOCOL_ID_FIELD_NAME], tumor_pair_list
+            )
+        }
+
+        # for each run, generate the config and upload template
+        wes_analysis_template = Template.from_type("wes_analysis")
+        wes_tumor_only_analysis_template = Template.from_type("wes_tumor_only_analysis")
         for run in potential_new_runs:
-            # if we have data files for *both* items in a tumor/normal pair
-            if (
-                run.normal_cimac_id
-                and run.normal_cimac_id in all_wes_records
-                and run.tumor_cimac_id in all_wes_records
-            ):
-                # then this is a run we need, and so we render it
-                res[run.run_id + ".yaml"] = self.analysis_config.render(
-                    **{
-                        "run_id": run.run_id,
-                        "tumor_sample": all_wes_records[run.tumor_cimac_id],
-                        "normal_sample": all_wes_records[run.normal_cimac_id],
-                        "BIOFX_BUCKET_NAME": bucket,
-                    }
-                )
-
-            # if there's no matching normal or doesn't have the files,
-            # render it as a tumor_only sample if we have its data files
-            elif run.tumor_cimac_id in all_wes_records:
-                # use tumor CIMAC ID as run_id if not given (formatted in jinja)
-                run_id = run.run_id if run.run_id else run.tumor_cimac_id
-                res[run_id + ".yaml"] = self.tumor_only_analysis_config.render(
-                    **{
-                        "run_id": run_id,
-                        "tumor_sample": all_wes_records[run.tumor_cimac_id],
-                        "BIOFX_BUCKET_NAME": bucket,
-                    }
-                )
+            run_id: str = run.run_id if run.run_id else run.tumor_cimac_id
+            res[run_id + ".yaml"] = self._generate_run_config(
+                run,
+                all_wes_records=all_wes_records,
+                bucket=bucket,
+            )
+            res[run_id + ".template.xlsx"] = self._generate_template_excel(
+                run,
+                all_wes_records=all_wes_records,
+                wes_analysis_template=wes_analysis_template,
+                wes_tumor_only_analysis_template=wes_tumor_only_analysis_template,
+            )
 
         return res
 

--- a/cidc_schemas/template.py
+++ b/cidc_schemas/template.py
@@ -1323,11 +1323,17 @@ class Template:
             or os.path.basename(template_schema_path).partition("_template.json")[0],
         )
 
-    def to_excel(self, xlsx_path: str):
-        """Write this `Template` to an Excel file"""
+    def to_excel(self, xlsx_path: str, close: bool = True):
+        """
+        Write this `Template` to an Excel file
+
+        Arguments:
+            xlsx_path {str} -- desired output path of the resulting xlsx file
+            close {bool} = True -- whether to close the workbook or to return it
+        """
         from .template_writer import XlTemplateWriter
 
-        XlTemplateWriter().write(xlsx_path, self)
+        return XlTemplateWriter().write(xlsx_path, self, close=close)
 
     def validate_excel(self, xlsx: Union[str, BinaryIO]) -> bool:
         """Validate the given Excel file (either a path or an open file) against this `Template`"""

--- a/cidc_schemas/template_writer.py
+++ b/cidc_schemas/template_writer.py
@@ -121,13 +121,16 @@ class XlTemplateWriter:
         self.DATA_ROWS = data_rows
         self.COLUMN_WIDTH_PX = column_width_px
 
-    def write(self, outfile_path: str, template: Template):
+    def write(
+        self, outfile_path: str, template: Template, close: bool = True
+    ) -> Optional[xlsxwriter.Workbook]:
         """
         Generate an Excel file for the given template.
 
         Arguments:
             outfile_path {str} -- desired output path of the resulting xlsx file
             template {Template} -- the template configuration from which to generate an Excel file
+            close {bool} = True -- whether to close the workbook or to return it
         """
         self.path = outfile_path
         self.template = template
@@ -148,8 +151,11 @@ class XlTemplateWriter:
             self._write_worksheet(name, ws_schema, worksheet, write_title=first_sheet)
             first_sheet = False
 
-        self.workbook.close()
-        self.workbook = None
+        if close:
+            self.workbook.close()
+            self.workbook = None
+        else:
+            return self.workbook
 
     _data_dict_sheet_name = "Data Dictionary"
 

--- a/tests/prism/test_pipelines.py
+++ b/tests/prism/test_pipelines.py
@@ -163,12 +163,6 @@ def test_WES_pipeline_config_generation_after_prismify(prismify_result, template
                 # test 1 tumor sample with no paired normal
                 partic["samples"][0]["processed_sample_derivative"] = "Tumor DNA"
                 partic["samples"][0]["collection_event_name"] = "On_Treatment"
-    print(
-        {
-            s["cimac_id"]: s.get("processed_sample_derivative")
-            for s in full_ct["participants"][0]["samples"]
-        }
-    )
 
     patch_with_artifacts = prism_patch_stage_artifacts(prismify_result, template.type)
 

--- a/tests/prism/test_pipelines.py
+++ b/tests/prism/test_pipelines.py
@@ -1,13 +1,11 @@
 """Tests for pipeline config generation."""
-from cidc_schemas.prism.merger import ArtifactInfo
 import os
 import copy
 import yaml
-import csv
 
 import pytest
 
-from cidc_schemas.template import Template, _TEMPLATE_PATH_MAP
+from cidc_schemas.template import Template
 from cidc_schemas.template_reader import XlTemplateReader
 from cidc_schemas.prism import core, pipelines, merger
 
@@ -188,16 +186,19 @@ def test_WES_pipeline_config_generation_after_prismify(prismify_result, template
     pairing_filename = full_ct["protocol_identifier"] + "_pairing.csv"
     # wes_bam
     if template.type == "wes_bam":
-        # in other cases - 2 config, tumor-only for both samples
-        assert len(res) == 3
+        # 2 config, tumor-only for both samples
+        # 2 template, wes_tumor_only_analysis for both
+        # 1 pairing file
+        assert len(res) == 5
         assert (
             res[pairing_filename]
             == "protocol_identifier,test_prism_trial_id\ntumor,tumor_collection_event,normal,normal_collection_event\nCTTTPP111.00,Not_reported,CTTTPP121.00,Not_reported"
         )
     elif template.type == "tumor_normal_pairing":
-        # only returns tumor/normal config
-        # config for CTTTPP122.00 was generated on wes_fastq upload
-        assert len(res) == 2  # pairing still only for 1
+        # 1 config, tumor/normal, config for CTTTPP122.00 was generated on wes_fastq upload
+        # 1 template, wes_analysis for pair
+        # 1 pairing file
+        assert len(res) == 3
         assert (
             res[pairing_filename] == "protocol_identifier,test_prism_trial_id\n"
             "tumor,tumor_collection_event,normal,normal_collection_event\n"
@@ -214,8 +215,10 @@ def test_WES_pipeline_config_generation_after_prismify(prismify_result, template
             "CTTTPP511.00,On_Treatment,,"
         )
     elif template.type == "wes_fastq":
-        # 16 configs, tumor-only for all 16 samples
-        assert len(res) == 17
+        # 16 configs, tumor-only for all samples
+        # 16 wes_tumor_only_analysis for all
+        # 1 pairing file
+        assert len(res) == 33
         assert (
             res[pairing_filename] == "protocol_identifier,test_prism_trial_id\n"
             "tumor,tumor_collection_event,normal,normal_collection_event\n"
@@ -238,8 +241,6 @@ def test_WES_pipeline_config_generation_after_prismify(prismify_result, template
     for fname, conf in res.items():
         if fname != pairing_filename:
             conf = yaml.load(conf, Loader=yaml.FullLoader)
-            print(conf)
-
             assert len(conf["metasheet"]) == 1  # one run
 
             if "pair" in template.type:


### PR DESCRIPTION
## What

When generating the WES analysis configurations, also setup an ingestion template and attach that as well.

## Why

[CIDC-1393](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1393) WES Analysis metadata template generated for biofx to use going forward

## How

- Extend current empty template writing functionality to return file without `close`ing
- Hard code location of values, and value for `folder` as provided by Len

## Remarks

- `xlsxwriter` best practice for writing to a buffer is using a `NamedTemporaryFile`
- returns as `bytes` instead of `str`, so corresponding API expansion needed with bump
- for testing `openpyxl` needs to use a `NamedTemporaryFile` with the `.xlsx` suffix particularly

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
