### PR TITLE
CIDC-1388 fix oneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.46` - 13 Jul 2022
+
+- `added` not to required for oneOf
+
 ## Version `0.25.45` - 13 Jul 2022
 
 - `changed` move WES analysis cnvkit to copynumber

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.45"
+__version__ = "0.25.46"

--- a/cidc_schemas/schemas/assays/wes_core.json
+++ b/cidc_schemas/schemas/assays/wes_core.json
@@ -481,6 +481,12 @@
 		},
 		"oneOf": [
 			{
+				"not": {
+					"required": [
+						"vcf_gz_tnscope_filter",
+						"maf_tnscope_filter"
+					]
+				},
 				"required": [
 					"vcf_gz_tnscope_output",
 					"tnscope_output_twist_filtered_vcf",


### PR DESCRIPTION
## What

Add `not` so there cannot be multiple valid for `oneOf`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
