### PR TITLE
CIDC-1424 add filepath map for upload types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.51` - 11 Aug 2022
+
+- `added` mapping from upload_type to filepath prefix
+
 ## Version `0.25.50` - 9 Aug 2022
 
 - `removed` strict requirement for percent tumor tissue area in hande manifest

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.50"
+__version__ = "0.25.51"

--- a/cidc_schemas/prism/constants.py
+++ b/cidc_schemas/prism/constants.py
@@ -1,5 +1,8 @@
 """CIDC schemas-specific constants relevant to prismifying/merging functionality."""
 
+from typing import Dict
+
+
 PROTOCOL_ID_FIELD_NAME = "protocol_identifier"
 
 SUPPORTED_ASSAYS = [
@@ -53,3 +56,44 @@ SUPPORTED_ANALYSES = [
 ]
 
 SUPPORTED_TEMPLATES = SUPPORTED_ASSAYS + SUPPORTED_MANIFESTS + SUPPORTED_ANALYSES
+
+# provide a way to get file-path prefix for each upload_type
+ASSAY_TO_FILEPATH: Dict[str, str] = {
+    # analysis is removed on some
+    "atacseq_analysis": "atacseq",
+    "rna_level1_analysis": "rna",
+    "wes_analysis": "wes",
+    "wes_tumor_only_analysis": "wes_tumor_only",
+    # assay specifics removed
+    "atacseq_fastq": "atacseq",
+    "rna_bam": "rna",
+    "rna_fastq": "rna",
+    "tcr_adaptive": "tcr",
+    "tcr_fastq": "tcr",
+    "wes_bam": "wes",
+    "wes_fastq": "wes",
+    # special cases
+    "clinical_data": "clinical",
+    "participants info": "participants",
+    "samples info": "samples",
+    # invariant
+    **{
+        k: k
+        for k in [
+            "ctdna_analysis",
+            "cytof_analysis",
+            "microbiome_analysis",
+            "tcr_analysis",
+            "ctdna",
+            "cytof",
+            "elisa",
+            "hande",
+            "ihc",
+            "microbiome",
+            "mif",
+            "misc_data",
+            "nanostring",
+            "olink",
+        ]
+    },
+}

--- a/tests/prism/test_constants.py
+++ b/tests/prism/test_constants.py
@@ -1,0 +1,13 @@
+from cidc_schemas.prism.constants import (
+    ASSAY_TO_FILEPATH,
+    SUPPORTED_ASSAYS,
+    SUPPORTED_ANALYSES,
+    SUPPORTED_MANIFESTS,
+)
+
+
+def test_assay_to_filepath():
+    assert sorted(list(ASSAY_TO_FILEPATH.keys())) == sorted(
+        SUPPORTED_ASSAYS + SUPPORTED_ANALYSES + ["participants info", "samples info"]
+    )
+    assert all(manifest not in ASSAY_TO_FILEPATH for manifest in SUPPORTED_MANIFESTS)


### PR DESCRIPTION
## What

Enable removing clinical data from cross-trial by providing filepath prefixes for each assay:
- Add a mapping between `upload_type`s and their top-level filepath from the templates.
- Also special values `participants info` and `samples info`

## Why

- [CIDC-1424](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1424) Make changes to portal access provider to simplify enabling clinical data access

## How

- Manually added a dict
- Added test to make sure all intended values are included

## Remarks

- Could extend the test to make sure it's correct based on the GCS URIs in the templates

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
