### PR TITLE
CIDC-1422 add string for null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.52` - 15 Aug 2022
+
+- `added` possibility for string values to some ctdna analysis columns
+
 ## Version `0.25.51` - 11 Aug 2022
 
 - `added` mapping from upload_type to filepath prefix

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.25.51"
+__version__ = "0.25.52"

--- a/cidc_schemas/schemas/assays/ctdna_analysis.json
+++ b/cidc_schemas/schemas/assays/ctdna_analysis.json
@@ -58,10 +58,8 @@
 				"other_solutions": {"$ref": "artifacts/artifact_pdf.json"},
 
 				"fraction_cna_subclonal": {
-					"description": "Fraction of copy number altered bins that are subclonal. (0-1)",
-					"type": "number",
-					"minimum": 0,
-					"maximum": 1
+					"description": "Fraction of copy number altered bins that are subclonal. Accepts NaN. (0-1)",
+					"type": ["number", "string"]
 				},
 				"fraction_genome_subclonal": {
 					"description": "Fraction of all (genomic) bins that are subclonal. (0-1)",
@@ -74,10 +72,8 @@
 					"type": "number"
 				},
 				"subclone_fraction": {
-					"description": "Fraction of tumor-derived DNA that is subclonal. (0-1)",
-					"type": "number",
-					"minimum": 0,
-					"maximum": 1
+					"description": "Fraction of tumor-derived DNA that is subclonal. Accepts NA. (0-1)",
+					"type": ["number", "string"]
 				},
 				"tumor_fraction": {
 					"description": "Estimated fraction of tumor-derived DNA. Equivalent to purity in bulk tumor analysis. (0-1)",


### PR DESCRIPTION
## What

Add possibility for string values to some ctdna analysis columns for null values

## Why

10047 ctdna analysis contains null values

## How

Add string to possible type, removing min/max

## Remarks

No test

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
