### PR TITLE
CIDC-1378 handle versioned clinical CSVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.26.1` - 7 Oct 2022
+
+- `added` handling for clinical CSV files with version as first row
+
 ## Version `0.26.0` - 14 Sep 2022
 
 - `changed` change schemas documentation format for the portal

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.26.0"
+__version__ = "0.26.1"

--- a/cidc_schemas/prism/extra_metadata.py
+++ b/cidc_schemas/prism/extra_metadata.py
@@ -163,7 +163,9 @@ def parse_clinical(file: BinaryIO) -> dict:
     except:
 
         # seek back to the beginning of the file
-        if file.seekable():
+        file.seek(0)
+        # if it starts with a version, just skip it
+        if not file.readline().startswith("version,"):
             file.seek(0)
 
         try:

--- a/cidc_schemas/prism/extra_metadata.py
+++ b/cidc_schemas/prism/extra_metadata.py
@@ -165,7 +165,8 @@ def parse_clinical(file: BinaryIO) -> dict:
         # seek back to the beginning of the file
         file.seek(0)
         # if it starts with a version, just skip it
-        if not file.readline().startswith("version,"):
+        firstline = file.readline()
+        if not firstline.startswith(b"version,"):
             file.seek(0)
 
         try:

--- a/tests/data/clinical_test_file.2.csv
+++ b/tests/data/clinical_test_file.2.csv
@@ -1,0 +1,6 @@
+version,2001-01-01 00:00:00
+Arm,Time Point,Cohort,Date of screening,Date of titration,Biobank sample ID,cimac_part_id
+sdf,sdf,fsd,df,sdf,sdf,CNQAABC
+fds,sdf,df,df,fds,sdf,CNQAABD
+sdf,fds,df,fsd,sdf,sdf,
+sdf,fds,df,fsd,sdf,sdf,CNQAABQ

--- a/tests/prism/test_extra_metadata.py
+++ b/tests/prism/test_extra_metadata.py
@@ -1,7 +1,4 @@
 import os
-from io import BytesIO
-from typing import BinaryIO
-from zipfile import BadZipFile
 
 import pytest
 
@@ -61,6 +58,7 @@ elisa_metadata_2 = {
 
 # CLINCAL file and metadata
 clinical_file_path_1_csv = os.path.join(TEST_DATA_DIR, "clinical_test_file.1.csv")
+clinical_file_path_2_csv = os.path.join(TEST_DATA_DIR, "clinical_test_file.2.csv")
 clinical_file_path_1 = os.path.join(TEST_DATA_DIR, "clinical_test_file.1.xlsx")
 clinical_metadata_1 = {
     "number_of_participants": 3,
@@ -130,6 +128,12 @@ def test_parse_clinical():
     # this tests csv parsing
     clinical_file_path_1_csv = os.path.join(TEST_DATA_DIR, "clinical_test_file.1.csv")
     with open(clinical_file_path_1_csv, "rb") as f:
+        data = parse_clinical(f)
+        _check_clin_eq(data, clinical_metadata_1)
+
+    # this tests versioned csv parsing
+    clinical_file_path_2_csv = os.path.join(TEST_DATA_DIR, "clinical_test_file.2.csv")
+    with open(clinical_file_path_2_csv, "rb") as f:
         data = parse_clinical(f)
         _check_clin_eq(data, clinical_metadata_1)
 


### PR DESCRIPTION
## What

Discovered in reprocessing of 10104/ABTC1603 clinical data under new scheme where first line includes a version date.

## How

If it exists, just skip it.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
