### PR TITLE
CIDC-1507 tweak upload folder re Len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.26.5` - 26 Oct 2022
+
+- `changed` upload folder used for making WES pipeline templates
+
 ## Version `0.26.4` - 24 Oct 2022
 
 - `changed` pipeline configuration generated for RIMA and WES

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.26.4"
+__version__ = "0.26.5"

--- a/cidc_schemas/prism/pipelines.py
+++ b/cidc_schemas/prism/pipelines.py
@@ -13,9 +13,7 @@ from .constants import PROTOCOL_ID_FIELD_NAME, SUPPORTED_SHIPPING_MANIFESTS
 from ..template import Template
 from ..util import load_pipeline_config_template, participant_id_from_cimac
 
-BIOFX_WES_ANALYSIS_FOLDER: str = "/mnt/ssd/wes/analysis"
 logger = logging.getLogger(__file__)
-
 
 # Note, bucket names must be all lowercase, dash, and underscore
 # https://cloud.google.com/storage/docs/naming-buckets#requirements
@@ -25,6 +23,10 @@ def RNA_GOOGLE_BUCKET_PATH_FN(trial_id: str, batch_num: int) -> str:
 
 def RNA_INSTANCE_NAME_FN(trial_id: str, batch_num: int) -> str:
     return f"rima_{trial_id}_set{batch_num+1}"
+
+
+def BIOFX_WES_ANALYSIS_FOLDER(trial_id: str, cimac_id: str) -> str:
+    return f"gs://repro_{trial_id}/WES_v3/{cimac_id}/analysis"
 
 
 def WES_GOOGLE_BUCKET_PATH_FN(trial_id: str, run_id: str) -> str:
@@ -197,7 +199,9 @@ class _Wes_pipeline_config:
                 worksheet = workbook.get_worksheet_by_name("WES Analysis")
 
                 worksheet.write(1, 2, trial_id)
-                worksheet.write(2, 2, BIOFX_WES_ANALYSIS_FOLDER)
+                worksheet.write(
+                    2, 2, BIOFX_WES_ANALYSIS_FOLDER(trial_id, run.tumor_cimac_id)
+                )
                 worksheet.write(6, 1, run.run_id)
                 worksheet.write(6, 2, run.normal_cimac_id)
                 worksheet.write(6, 3, run.tumor_cimac_id)
@@ -213,7 +217,9 @@ class _Wes_pipeline_config:
                 worksheet = workbook.get_worksheet_by_name("WES tumor-only Analysis")
 
                 worksheet.write(1, 2, trial_id)
-                worksheet.write(2, 2, BIOFX_WES_ANALYSIS_FOLDER)
+                worksheet.write(
+                    2, 2, BIOFX_WES_ANALYSIS_FOLDER(trial_id, run.tumor_cimac_id)
+                )
                 worksheet.write(6, 1, run.run_id)
                 worksheet.write(6, 2, run.tumor_cimac_id)
 

--- a/tests/prism/test_pipelines.py
+++ b/tests/prism/test_pipelines.py
@@ -303,7 +303,6 @@ def test_WES_pipeline_config_generation_after_prismify(prismify_result, template
                     ), f"Attached xlsx doesn't have right worksheets: {wb.sheetnames}"
 
                 assert sht["C2"].value == "test_prism_trial_id"
-                assert sht["C3"].value == pipelines.BIOFX_WES_ANALYSIS_FOLDER
                 assert sht["B7"].value  # run name
                 assert sht["C7"].value  # first id
 
@@ -312,6 +311,12 @@ def test_WES_pipeline_config_generation_after_prismify(prismify_result, template
                     assert sht["B7"].value == sht["D7"].value  # run name is tumor id
                 else:
                     assert sht["B7"].value == sht["C7"].value  # run name is tumor id
+
+                # loading folder is based on the trial and tumor cimac (ie run) ids
+                assert (
+                    sht["C3"].value
+                    == f"gs://repro_test_prism_trial_id/WES_v3/{sht['B7'].value}/analysis"
+                )
 
             # check the config template excels
             else:  # if "wes_ingestion" in fname


### PR DESCRIPTION
## What

Change folder used for generating WES analysis upload templates

## Why

> Hi Stephen,
One thing I just saw about the ingestion sheets is that the Folder field is set to /mnt/ssd/wes/analysis, which would be correct if we were ingesting files locally.  But with wes monitor we'll be ingesting wes data from the repro buckets.  Could you change the script to autofill that field to: gs://repro_{trial}/WES_v3/{CIMAC ID for tmr}/analysis ?
That will help us out alot!
Regards,
Len


## How

- Convert str to function returning string
- update test

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
