### PR TITLE
CIDC-1519 add participant counting for csv files with unquoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.26.7` - 27 Oct 2022
+
+- `fixed` clinical data participant counting for csv files with unqouted strings
+
 ## Version `0.26.6` - 27 Oct 2022
 
 - `fixed` clinical data participant counting for versioned CSV files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 
 ## Version `0.26.7` - 27 Oct 2022
 
-- `fixed` clinical data participant counting for csv files with unqouted strings
+- `fixed` clinical data participant counting for csv files with unquoted strings
 
 ## Version `0.26.6` - 27 Oct 2022
 

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.26.6"
+__version__ = "0.26.7"

--- a/cidc_schemas/prism/extra_metadata.py
+++ b/cidc_schemas/prism/extra_metadata.py
@@ -176,7 +176,9 @@ def parse_clinical(file: BinaryIO) -> dict:
         # via API, pandas still reads it even if we don't seek back
         # so instead pass as skiprows
         firstline = file.readline()
-        skiprows: int = int(firstline.startswith(b'"version",'))
+        skiprows: int = int(
+            firstline.startswith(b'"version",') or firstline.startswith(b"version,")
+        )
         file.seek(0)
 
         try:

--- a/tests/data/clinical_test_file.2.csv
+++ b/tests/data/clinical_test_file.2.csv
@@ -1,4 +1,4 @@
-"version",2001-01-01 00:00:00
+version,2001-01-01 00:00:00
 "Arm","Time Point","Cohort","Date of screening","Date of titration","Biobank sample ID","cimac_part_id"
 sdf,sdf,fsd,df,sdf,sdf,CNQAABC
 fds,sdf,df,df,fds,sdf,CNQAABD

--- a/tests/prism/test_extra_metadata.py
+++ b/tests/prism/test_extra_metadata.py
@@ -136,7 +136,7 @@ def test_parse_clinical():
     # this tests versioned csv parsing
     clinical_file_path_2_csv = os.path.join(TEST_DATA_DIR, "clinical_test_file.2.csv")
     with open(clinical_file_path_2_csv, "rb") as f:
-        assert f.read().startswith(b'"version",')
+        assert f.read().startswith(b"version,")
         f.seek(0)
         data = parse_clinical(f)
         _check_clin_eq(data, clinical_metadata_1)


### PR DESCRIPTION
## What

add participant counting for csv files with unquoted strings

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
