### PR TITLE
fix #561 account for BOM in versioned files

### DIFF
--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.26.8"
+__version__ = "0.26.9"

--- a/cidc_schemas/prism/extra_metadata.py
+++ b/cidc_schemas/prism/extra_metadata.py
@@ -1,6 +1,7 @@
 """Parsers for extracting extra metadata from files containing molecular data."""
 import logging
 import re
+from codecs import BOM_UTF8
 from typing import BinaryIO
 
 import openpyxl
@@ -176,6 +177,8 @@ def parse_clinical(file: BinaryIO) -> dict:
         # via API, pandas still reads it even if we don't seek back
         # so instead pass as skiprows
         firstline = file.readline()
+        # handle an edge case where the file starts with a Byte Order Mark
+        firstline = firstline.removeprefix(BOM_UTF8)
         skiprows: int = int(
             firstline.startswith(b'"version",') or firstline.startswith(b"version,")
         )

--- a/tests/data/clinical_test_file.2.bom.csv
+++ b/tests/data/clinical_test_file.2.bom.csv
@@ -1,0 +1,6 @@
+﻿version,2001-01-01 00:00:00
+"Arm","Time Point","Cohort","Date of screening","Date of titration","Biobank sample ID","cimac_part_id"
+sdf,sdf,fsd,df,sdf,sdf,CNQAABC
+fds,sdf,df,df,fds,sdf,CNQAABD
+sdf,fds,df,fsd,sdf,sdf,
+sdf,fds,df,fsd,sdf,sdf,CNQAABQ

--- a/tests/prism/test_extra_metadata.py
+++ b/tests/prism/test_extra_metadata.py
@@ -154,3 +154,11 @@ def test_parse_clinical():
     # this tests if not xlsx/csv files don't get anything
     with open(clinical_docx, "rb") as f:
         assert parse_clinical(f) == {}
+
+    # this tests a versioned csv containing a BOM
+    clinical_file_path_2_bom_csv = os.path.join(
+        TEST_DATA_DIR, "clinical_test_file.2.bom.csv"
+    )
+    with open(clinical_file_path_2_bom_csv, "rb") as f:
+        data = parse_clinical(f)
+        _check_clin_eq(data, clinical_metadata_1)


### PR DESCRIPTION
## What

If a BOM is present in the first line, remove it before checking if the line starts with `b"version"`.

## Why

Fixes issue #561.

## Checklist

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
