### PR TITLE
CIDC-876 change file derivation to return None instead of erroring when not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.26.11` - 8 Nov 2022
+
+- `changed` derive files to return None instead of erroring when no derivation is defined
+
 ## Version `0.26.10` - 7 Nov 2022
 
 - `changed` handling of clinical CSV files to strip any initial BOM

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.26.11"
+__version__ = "0.26.12"

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.26.10"
+__version__ = "0.26.11"

--- a/cidc_schemas/unprism.py
+++ b/cidc_schemas/unprism.py
@@ -47,7 +47,7 @@ def _register_derivation(upload_type: str):
     return decorator
 
 
-def derive_files(context: DeriveFilesContext) -> DeriveFilesResult:
+def derive_files(context: DeriveFilesContext) -> Optional[DeriveFilesResult]:
     """
     Derive files from a trial_metadata blob given an `upload_type`
 
@@ -64,15 +64,12 @@ def derive_files(context: DeriveFilesContext) -> DeriveFilesResult:
 
     Returns
     -------
-    DeriveFilesResult(NamedTuple)
-        with attributes:
+    Optional[DeriveFilesResult(NamedTuple)]
+        if not None, with attributes:
             artifacts: List[Artifact]
             trial_metadata: dict
 
-    Raises
-    ------
-    NotImplementedError
-        if context.upload_type does not have a defined file derivation
+        None if context.upload_type does not have a defined file derivation
         all prism.SUPPORTED_SHIPPING_MANIFESTS are supported via _shipping_manifest_derivation()
         otherwise use wrapper @_register_derivation(upload_type: str)
     """
@@ -81,10 +78,6 @@ def derive_files(context: DeriveFilesContext) -> DeriveFilesResult:
 
     if context.upload_type in _upload_type_derivations:
         return _upload_type_derivations[context.upload_type](context)
-
-    raise NotImplementedError(
-        f"No file derivations for upload type {context.upload_type}"
-    )
 
 
 def _build_artifact(

--- a/cidc_schemas/unprism.py
+++ b/cidc_schemas/unprism.py
@@ -48,7 +48,34 @@ def _register_derivation(upload_type: str):
 
 
 def derive_files(context: DeriveFilesContext) -> DeriveFilesResult:
-    """Derive files from a trial_metadata blob given an `upload_type`"""
+    """
+    Derive files from a trial_metadata blob given an `upload_type`
+
+    Parameters
+    ----------
+    context: DeriveFilesContext(NamedTuple)
+        with attributes:
+            trial_metadata: dict
+            upload_type: str
+            fetch_artifact: Callable[[str, bool], Optional[Union[StringIO, BytesIO]]]
+              * should return None if no artifact is found.
+              * arg1 (str): object_url
+              * arg2 (bool): if True, return artifact as StringIO, otherwise BytesIO.
+
+    Returns
+    -------
+    DeriveFilesResult(NamedTuple)
+        with attributes:
+            artifacts: List[Artifact]
+            trial_metadata: dict
+
+    Raises
+    ------
+    NotImplementedError
+        if context.upload_type does not have a defined file derivation
+        all prism.SUPPORTED_SHIPPING_MANIFESTS are supported via _shipping_manifest_derivation()
+        otherwise use wrapper @_register_derivation(upload_type: str)
+    """
     if context.upload_type in prism.SUPPORTED_SHIPPING_MANIFESTS:
         return _shipping_manifest_derivation(context)
 


### PR DESCRIPTION
## Why

- [CIDC-876](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-876) derive_files_from_... cloud functions throw errors when no derivation is implemented

## How

- Remove hardcoded `raise`

## Remarks

- will need to handle `None` return in [`upload_postprocessing`](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/functions/upload_postprocessing.py) CFn
- no current test for error

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
