### PR TITLE
CIDC-1554 assert prefix codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.26.16` - 02 Dec 2022
+
+- `added` assertion that non-identical file-path prefixes for upload_type must not overlap
+
 ## Version `0.26.15` - 01 Dec 2022
 
 - `changed` update dateparser version in order to fix PEP 495 compliance error

--- a/cidc_schemas/__init__.py
+++ b/cidc_schemas/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """James Lindsay"""
 __email__ = "jlindsay@jimmy.harvard.edu"
-__version__ = "0.26.15"
+__version__ = "0.26.16"

--- a/cidc_schemas/prism/constants.py
+++ b/cidc_schemas/prism/constants.py
@@ -58,25 +58,25 @@ SUPPORTED_TEMPLATES = SUPPORTED_ASSAYS + SUPPORTED_MANIFESTS + SUPPORTED_ANALYSE
 # provide a way to get file-path prefix for each upload_type
 ASSAY_TO_FILEPATH: Dict[str, str] = {
     # analysis is removed on some
-    "atacseq_analysis": "atacseq",
-    "rna_level1_analysis": "rna",
-    "wes_analysis": "wes",
-    "wes_tumor_only_analysis": "wes_tumor_only",
+    "atacseq_analysis": "atacseq/",
+    "rna_level1_analysis": "rna/",
+    "wes_analysis": "wes/",
+    "wes_tumor_only_analysis": "wes_tumor_only/",
     # assay specifics removed
-    "atacseq_fastq": "atacseq",
-    "rna_bam": "rna",
-    "rna_fastq": "rna",
-    "tcr_adaptive": "tcr",
-    "tcr_fastq": "tcr",
-    "wes_bam": "wes",
-    "wes_fastq": "wes",
+    "atacseq_fastq": "atacseq/",
+    "rna_bam": "rna/",
+    "rna_fastq": "rna/",
+    "tcr_adaptive": "tcr/",
+    "tcr_fastq": "tcr/",
+    "wes_bam": "wes/",
+    "wes_fastq": "wes/",
     # special cases
-    "clinical_data": "clinical",
-    "participants info": "participants",
-    "samples info": "samples",
+    "clinical_data": "clinical/",
+    "participants info": "participants/",
+    "samples info": "samples/",
     # invariant
     **{
-        k: k
+        k: f"{k}/"
         for k in [
             "cytof_analysis",
             "tcr_analysis",
@@ -94,3 +94,9 @@ ASSAY_TO_FILEPATH: Dict[str, str] = {
         ]
     },
 }
+assert all(
+    not prefix1.startswith(prefix2)
+    for prefix1 in ASSAY_TO_FILEPATH.values()
+    for prefix2 in ASSAY_TO_FILEPATH.values()
+    if prefix1 != prefix2
+), "Prefix codes may not be overlapping"


### PR DESCRIPTION
## What

Add assertion that non-identical file-path prefixes for upload_type must not overlap

## Why

[CIDC-1554](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1554) Check in dev alerts for permissions and what is triggering them
When there is overlap, tries to update same file twice for cross-assay.

## How

Add assertion, convert with trailing `/`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
