### PR TITLE
remove report from atacseq

### DIFF
--- a/cidc_schemas/template.py
+++ b/cidc_schemas/template.py
@@ -265,14 +265,6 @@ def _initialize_template_schema(name: str, title: str, pointer: str):
             "merge_pointer": "0/batch_id",
             "type_ref": "assays/atacseq_assay.json#properties/batch_id",
         }
-        template["properties"]["worksheets"][f"{title} Analysis"]["preamble_rows"][
-            "report"
-        ] = {
-            "merge_pointer": "0/report",
-            "type_ref": "assays/components/local_file.json#properties/file_path",
-            "gcs_uri_format": "{protocol identifier}/atacseq/analysis/{batch id}/report.zip",
-            "is_artifact": 1,
-        }
 
     return template
 

--- a/docs/docs/assays.atacseq.atacseq_analysis_template.html
+++ b/docs/docs/assays.atacseq.atacseq_analysis_template.html
@@ -167,37 +167,6 @@
                 
             
         
-            
-            
-            
-                
-                    <tr>
-    <td>
-        
-            <span id="report">
-                report
-            </span>
-            
-                <br><sup><mark>required</mark></sup>
-            
-        
-    </td>
-    <td width=55%>
-        
-            Information about a ZIP file.
-        
-    </td>
-    <td>
-        
-            <a href="files.zip.html">
-                zip
-            </a>
-        
-    </td>
-</tr>
-                
-            
-        
         
             
                 
@@ -239,12 +208,6 @@
                 
             
         
-            
-                
-            
-        
-        
-            
         
             
         

--- a/docs/docs/assays.atacseq.html
+++ b/docs/docs/assays.atacseq.html
@@ -1083,12 +1083,6 @@
                 
             
         
-            
-            
-            
-                
-            
-        
         
             
                 
@@ -1098,35 +1092,6 @@
                 
             
         
-            
-                
-                    <tr>
-    <td>
-        
-            <span id="report">
-                report
-            </span>
-            
-        
-    </td>
-    <td width=55%>
-        
-            Information about a ZIP file.
-        
-    </td>
-    <td>
-        
-            <a href="files.zip.html">
-                zip
-            </a>
-        
-    </td>
-</tr>
-                
-            
-        
-        
-            
         
             
         

--- a/tests/data/schemas/target-templates/atacseq_analysis_template.json
+++ b/tests/data/schemas/target-templates/atacseq_analysis_template.json
@@ -19,12 +19,6 @@
                     "batch id": {
                         "merge_pointer": "0/batch_id",
                         "type_ref": "assays/atacseq_assay.json#properties/batch_id"
-                    },
-                    "report": {
-                        "merge_pointer": "0/report",
-                        "type_ref": "assays/components/local_file.json#properties/file_path",
-                        "gcs_uri_format": "{protocol identifier}/atacseq/analysis/{batch id}/report.zip",
-                        "is_artifact": 1
                     }
                 },
                 "prism_data_object_pointer": "/records/-",


### PR DESCRIPTION
## What
Removes the report preamble field from atacseq anaylsis special handling code and tests. See this commit 75535d347273af99450eb85590bc70a1932e6ce3 for the origins of this change.

## Why

If I do the following,
1. Generate the analysis template schemas (from pre-commit)
2. Run pytest

I get an error with the atacseq analysis tests because the report field was added by the special handler in template.py.

## How

- Removed the atacseq special handling code template.py. 
- Regenerated the analysis templates to confirm the changes took effect
- Generated the docs/ to promote the new schema changes
- Reran pytest to confirm all tests are passing

## Remarks

Not bumping the package version because these changes are for development/documentation purposes.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and [README](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the Schemas package version in [`cidc_schemas/__init__.py`](https://github.com/CIMAC-CIDC/cidc-schemas/blob/master/cidc_schemas/__init__.py#L5)
